### PR TITLE
fix: View correlated messages of a message start event

### DIFF
--- a/src/main/resources/public/js/view-process.js
+++ b/src/main/resources/public/js/view-process.js
@@ -164,7 +164,7 @@ function loadMessageSubscriptionsOfProcess() {
               + ' Publish Message'
               + '</button>';
 
-          $("#message-subscriptions-of-process-table tbody:last-child").append('<tr>'
+          $("#message-subscriptions-of-process-table > tbody:last-child").append('<tr>'
               + '<td>' + (indexOffset + index) +'</td>'
               + '<td>' + messageSubscription.key + '</td>'
               + '<td>' + messageSubscription.messageName +'</td>'


### PR DESCRIPTION
## Description

* the view of correlated messages of a message start event was broken if the process has more than one message start event

## Related issues

closes #21