### PR TITLE
feat: show the properties of a user task

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <maven.version>3.0</maven.version>
-    <zeebe.version>8.0.5</zeebe.version>
-    <zeeqs.version>2.4.0</zeeqs.version>
+    <zeebe.version>8.1.4</zeebe.version>
+    <zeeqs.version>2.5.0</zeeqs.version>
     <eze.version>1.1.0</eze.version>
     <hazelcast.version>1.2.1</hazelcast.version>
 

--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -254,6 +254,8 @@ function formatBpmnElement(bpmnElementType) {
       return '<span class="bpmn-icon-service-task"></span>';
     case "EXCLUSIVE_GATEWAY":
       return '<span class="bpmn-icon-gateway-xor"></span>';
+    case "INCLUSIVE_GATEWAY":
+      return '<span class="bpmn-icon-gateway-or"></span>';
     case "PARALLEL_GATEWAY":
       return '<span class="bpmn-icon-gateway-parallel"></span>';
     case "EVENT_BASED_GATEWAY":
@@ -369,6 +371,13 @@ function showInfoOfBpmnElement(element) {
     info = 'message name: ' + subscription.messageName;
     if (subscription.messageCorrelationKey) {
       info += '<br>' + 'correlation key: ' + subscription.messageCorrelationKey;
+    }
+  }
+  if (metadata.userTaskAssignmentDefinition) {
+    let userTask = metadata.userTaskAssignmentDefinition;
+    info = 'assignee: ' + userTask.assignee;
+    if (userTask.candidateGroups) {
+      info += '<br>' + 'candidateGroups: ' + userTask.candidateGroups;
     }
   }
 

--- a/src/main/resources/public/js/zeeqs-client.js
+++ b/src/main/resources/public/js/zeeqs-client.js
@@ -119,6 +119,10 @@ const elementsInfoByProcessQuery = `query ElementsInfoOfProcess($key: ID!) {
             messageName
             messageCorrelationKey
           }
+          userTaskAssignmentDefinition {
+            assignee
+            candidateGroups
+          }
         }
       }
     }
@@ -372,6 +376,10 @@ const elementsInfoByProcessInstanceQuery = `query ElementsInfoOfProcessInstance(
             messageSubscriptionDefinition {
               messageName
               messageCorrelationKey
+            }
+            userTaskAssignmentDefinition {
+              assignee
+              candidateGroups
             }
           }
         }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

I can  see the following properties of a user task:

- assignee
- candidate groups

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #17 