### PR TITLE
feat: load user tasks of process instance

### DIFF
--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -71,6 +71,7 @@ function loadProcessInstanceDetailsViews() {
 
   loadElementInstancesOfProcessInstance();
   loadJobsOfProcessInstance();
+  loadUserTasksOfProcessInstance();
   loadIncidentsOfProcessInstance();
   loadMessageSubscriptionsOfProcessInstance();
   loadTimersOfProcessInstance();
@@ -563,6 +564,62 @@ function removeTaskPlayableMarkersOfJobs(jobs) {
   elementIdsOfNotActivatableJobs
       .filter(function (elementId) {
         return !elementIdsOfActivatableJobs.includes(elementId);
+      })
+      .forEach(function (elementId) {
+        removeTaskPlayableMarker(elementId);
+      });
+}
+
+function loadUserTasksOfProcessInstance() {
+
+  const processInstanceKey = getProcessInstanceKey();
+
+  queryUserTasksByProcessInstance(processInstanceKey)
+      .done(function (response) {
+
+        let processInstance = response.data.processInstance;
+        let userTasks = processInstance.userTasks;
+
+        let totalCount = userTasks.totalCount;
+        let nodes = userTasks.nodes;
+
+        // TODO (#67): show user tasks in tab
+
+        nodes.forEach((userTask, index) => {
+
+          const bpmnElement = userTask.elementInstance.element;
+          const elementId = bpmnElement.elementId;
+
+          const isActiveTask = userTask.state === "CREATED";
+          if (isActiveTask) {
+            makeTaskPlayable(elementId, userTask.key);
+          }
+        });
+
+        removeUserTaskMarkers(nodes);
+      });
+}
+
+function removeUserTaskMarkers(userTasks) {
+  let elementIdsOfActiveTasks = userTasks
+      .filter(function (userTask) {
+        return userTask.state === "CREATED";
+      })
+      .map(function (userTask) {
+        return userTask.elementInstance.element.elementId
+      });
+
+  let elementIdsOfNotActiveTasks = userTasks
+      .filter(function (userTask) {
+        return userTask.state !== "CREATED";
+      })
+      .map(function (userTask) {
+        return userTask.elementInstance.element.elementId
+      })
+
+  elementIdsOfNotActiveTasks
+      .filter(function (elementId) {
+        return !elementIdsOfActiveTasks.includes(elementId);
       })
       .forEach(function (elementId) {
         removeTaskPlayableMarker(elementId);

--- a/src/main/resources/public/js/zeeqs-client.js
+++ b/src/main/resources/public/js/zeeqs-client.js
@@ -285,6 +285,34 @@ const jobsByProcessInstanceQuery = `query JobsOfProcessInstance($key: ID!, $zone
     }
   }`;
 
+const userTasksByProcessInstanceQuery = `query UserTasksOfProcessInstance($key: ID!) {  
+    processInstance(key: $key) {    
+       userTasks(perPage: 100) {
+        totalCount
+        nodes {
+          key
+          state
+          
+          assignee
+          candidateGroups
+          
+          form {
+            resource
+          }
+          
+          elementInstance {
+            key
+            element {
+              elementId
+              elementName
+              bpmnElementType
+            }
+          }
+        }
+      }
+    }
+  }`;
+
 const incidentsByProcessInstanceQuery = `query IncidentsOfProcessInstance($key: ID!, $zoneId: String!) {  
     processInstance(key: $key) {    
       incidents {
@@ -637,6 +665,13 @@ function queryJobsByProcessInstance(processInstanceKey) {
   return fetchData(jobsByProcessInstanceQuery, {
     key: processInstanceKey,
     zoneId: getTimeZone()
+  });
+}
+
+function queryUserTasksByProcessInstance(processInstanceKey) {
+
+  return fetchData(userTasksByProcessInstanceQuery, {
+    key: processInstanceKey
   });
 }
 


### PR DESCRIPTION
## Description

Fetch user tasks of the process instance from ZeeQS. Add a marker for each active user task. Remove the marker from not active tasks.

Fix the demo process by making the user tasks completable again.

## Related issues

Related to #10 