### PR TITLE
fix: use proper websocket protocol for ssl encrypted connections

### DIFF
--- a/src/main/resources/public/js/zeeqs-client.js
+++ b/src/main/resources/public/js/zeeqs-client.js
@@ -773,7 +773,10 @@ function queryVariablesByUserTask(userTask) {
 }
 
 function subscribeToUpdates(type, key, handler) {
-  const socket = new WebSocket("ws://" + window.location.host + "/graphql");
+  const socketProtocol = window.location.protocol === "https:" ? "wss" : "ws";
+  const socket = new WebSocket(
+    socketProtocol + "://" + window.location.host + "/graphql"
+  );
 
   socket.addEventListener("open", () => {
     socket.send(JSON.stringify({ type: "connection_init", payload: {} }));


### PR DESCRIPTION
## Description

I could not really test it, but I am fairly certain that we need to use the `wss` protocol if Zeebe Play is running via an ssl encrypted connection.

## Related issues

related to #12 