### PR TITLE
Bundle Camunda connectors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,9 @@
     <zeeqs.version>2.7.0</zeeqs.version>
     <eze.version>1.1.0</eze.version>
     <hazelcast.version>1.2.1</hazelcast.version>
+    <spring-zeebe.version>8.1.15</spring-zeebe.version>
+    <camunda-connector-bundle.version>0.15.0</camunda-connector-bundle.version>
+    <camunda-connector-sdk.version>0.5.0</camunda-connector-sdk.version>
 
     <kotlin.version>1.8.0</kotlin.version>
     <spring.boot.version>2.7.8</spring.boot.version>
@@ -68,7 +71,7 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>spring-zeebe-starter</artifactId>
-        <version>8.1.15</version>
+        <version>${spring-zeebe.version}</version>
       </dependency>
 
       <dependency>
@@ -81,6 +84,24 @@
         <groupId>io.zeebe.hazelcast</groupId>
         <artifactId>zeebe-hazelcast-exporter</artifactId>
         <version>${hazelcast.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>connector-runtime-bundle</artifactId>
+        <version>${camunda-connector-bundle.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>connector-runtime-util</artifactId>
+        <version>${camunda-connector-sdk.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>connector-validation</artifactId>
+        <version>${camunda-connector-sdk.version}</version>
       </dependency>
 
       <dependency>
@@ -195,6 +216,28 @@
       <artifactId>zeebe-hazelcast-exporter</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-runtime-bundle</artifactId>
+      <exclusions>
+        <!-- The runtime causes errors in Spring. We don't need it. -->
+        <exclusion>
+          <groupId>io.camunda</groupId>
+          <artifactId>spring-zeebe-connector-runtime</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-runtime-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-validation</artifactId>
+    </dependency>
+
     <!-- Database drivers -->
 
     <dependency>
@@ -282,6 +325,7 @@
           </args>
           <compilerPlugins>
             <plugin>spring</plugin>
+            <plugin>jpa</plugin>
           </compilerPlugins>
           <jvmTarget>${version.java}</jvmTarget>
         </configuration>

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorProperties.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorProperties.kt
@@ -1,0 +1,16 @@
+package org.camunda.community.zeebe.play.connectors
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties("zeebe.connectors")
+data class ConnectorProperties(
+    val secrets: List<ConnectorSecretProperty> = emptyList()
+) {
+
+    data class ConnectorSecretProperty(
+        val name: String,
+        val value: String
+    )
+}

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorProperties.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorProperties.kt
@@ -6,7 +6,8 @@ import org.springframework.boot.context.properties.ConstructorBinding
 @ConstructorBinding
 @ConfigurationProperties("zeebe.connectors")
 data class ConnectorProperties(
-    val secrets: List<ConnectorSecretProperty> = emptyList()
+    val secrets: List<ConnectorSecretProperty> = emptyList(),
+    val enabled: Boolean = true
 ) {
 
     data class ConnectorSecretProperty(

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorSecret.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorSecret.kt
@@ -1,0 +1,11 @@
+package org.camunda.community.zeebe.play.connectors
+
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Entity
+data class ConnectorSecret(
+    @Id val name: String,
+    @Column(name = "value_") val value: String
+)

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorSecretRepository.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorSecretRepository.kt
@@ -1,0 +1,8 @@
+package org.camunda.community.zeebe.play.connectors
+
+import org.springframework.data.repository.PagingAndSortingRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ConnectorSecretRepository: PagingAndSortingRepository<ConnectorSecret, String> {
+}

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
@@ -4,6 +4,7 @@ import io.camunda.connector.api.secret.SecretProvider
 import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler
 import io.camunda.connector.runtime.util.outbound.OutboundConnectorRegistrationHelper
 import io.camunda.zeebe.client.ZeebeClient
+import io.camunda.zeebe.spring.client.lifecycle.ZeebeClientLifecycle
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -26,8 +27,15 @@ class ConnectorsConfig(
 
     @PostConstruct
     fun startConnectors() {
+        if (zeebeClient is ZeebeClientLifecycle) {
+            // The connectors are managed by the Spring Zeebe client itself.
+            return
+        }
+
         if (!connectorProperties.enabled) {
             logger.info("Zeebe connectors are disabled in the configuration.")
+            // Disabling doesn't work if the connectors are managed by Spring Zeebe.
+            // See https://github.com/camunda-community-hub/spring-zeebe/issues/325.
             return
         }
 

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
@@ -1,0 +1,40 @@
+package org.camunda.community.zeebe.play.connectors
+
+import io.camunda.connector.api.secret.SecretProvider
+import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler
+import io.camunda.connector.runtime.util.outbound.OutboundConnectorRegistrationHelper
+import io.camunda.zeebe.client.ZeebeClient
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import javax.annotation.PostConstruct
+
+@Configuration
+@EnableJpaRepositories
+@EntityScan
+class ConnectorsConfig(
+    private val zeebeClient: ZeebeClient,
+    private val secretProvider: SecretProvider) {
+
+    private val logger = LoggerFactory.getLogger(ConnectorsConfig::class.java)
+
+    @PostConstruct
+    fun `start connectors`() {
+
+        OutboundConnectorRegistrationHelper
+            .parseFromSPI()
+            .forEach { connectorConfig ->
+                zeebeClient
+                    .newWorker()
+                    .jobType(connectorConfig.type)
+                    .handler(ConnectorJobHandler(connectorConfig.function, secretProvider))
+                    .name(connectorConfig.name)
+                    .fetchVariables(connectorConfig.inputVariables.toList())
+                    .open()
+
+                logger.info("Start Camunda connector. [name: '${connectorConfig.name}', type: '${connectorConfig.type}']")
+            }
+    }
+
+}

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
@@ -25,7 +25,11 @@ class ConnectorsConfig(
     private val logger = LoggerFactory.getLogger(ConnectorsConfig::class.java)
 
     @PostConstruct
-    fun `start connectors`() {
+    fun startConnectors() {
+        if (!connectorProperties.enabled) {
+            logger.info("Zeebe connectors are disabled in the configuration.")
+            return
+        }
 
         OutboundConnectorRegistrationHelper
             .parseFromSPI()
@@ -43,7 +47,7 @@ class ConnectorsConfig(
     }
 
     @PostConstruct
-    fun `store connector secrets`() {
+    fun storeConnectorSecrets() {
         connectorProperties.secrets.forEach {
             val secret = ConnectorSecret(
                 name = it.name,

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsSecretProvider.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsSecretProvider.kt
@@ -1,0 +1,15 @@
+package org.camunda.community.zeebe.play.connectors
+
+import io.camunda.connector.api.secret.SecretProvider
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class ConnectorsSecretProvider(
+    private val connectorSecretRepository: ConnectorSecretRepository
+) : SecretProvider {
+
+    override fun getSecret(name: String): String? {
+        return connectorSecretRepository.findByIdOrNull(name)?.value
+    }
+}

--- a/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorSecretsResource.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorSecretsResource.kt
@@ -30,6 +30,9 @@ class ConnectorSecretsResource(
 
     @RequestMapping(path = ["/"], method = [RequestMethod.POST])
     fun setSecrets(@RequestBody dto: ConnectorSecretsDto) {
+        // place all secrets with the request data
+        repository.deleteAll()
+
         dto.secrets
             .map {
                 ConnectorSecret(

--- a/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorSecretsResource.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorSecretsResource.kt
@@ -1,0 +1,53 @@
+package org.camunda.community.zeebe.play.rest
+
+import org.camunda.community.zeebe.play.connectors.ConnectorSecret
+import org.camunda.community.zeebe.play.connectors.ConnectorSecretRepository
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/rest/connector-secrets")
+class ConnectorSecretsResource(
+    private val repository: ConnectorSecretRepository
+) {
+
+    @RequestMapping(path = ["/"], method = [RequestMethod.GET])
+    fun getSecrets(): ConnectorSecretsDto {
+        return repository.findAll()
+            .map {
+                ConnectSecretDto(
+                    name = it.name,
+                    value = it.value
+                )
+            }.let {
+                ConnectorSecretsDto(
+                    secrets = it
+                )
+            }
+    }
+
+    @RequestMapping(path = ["/"], method = [RequestMethod.POST])
+    fun setSecrets(@RequestBody dto: ConnectorSecretsDto) {
+        dto.secrets
+            .map {
+                ConnectorSecret(
+                    name = it.name,
+                    value = it.value
+                )
+            }
+            .let {
+                repository.saveAll(it)
+            }
+    }
+
+    data class ConnectorSecretsDto(
+        val secrets: List<ConnectSecretDto>
+    )
+
+    data class ConnectSecretDto(
+        val name: String,
+        val value: String
+    )
+}

--- a/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorSecretsResource.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorSecretsResource.kt
@@ -13,7 +13,7 @@ class ConnectorSecretsResource(
     private val repository: ConnectorSecretRepository
 ) {
 
-    @RequestMapping(path = ["/"], method = [RequestMethod.GET])
+    @RequestMapping(method = [RequestMethod.GET])
     fun getSecrets(): ConnectorSecretsDto {
         return repository.findAll()
             .map {
@@ -28,7 +28,7 @@ class ConnectorSecretsResource(
             }
     }
 
-    @RequestMapping(path = ["/"], method = [RequestMethod.POST])
+    @RequestMapping(method = [RequestMethod.POST])
     fun setSecrets(@RequestBody dto: ConnectorSecretsDto) {
         // place all secrets with the request data
         repository.deleteAll()

--- a/src/main/kotlin/org/camunda/community/zeebe/play/ui/ConnectorsView.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/ui/ConnectorsView.kt
@@ -1,0 +1,23 @@
+package org.camunda.community.zeebe.play.ui
+
+import org.springframework.stereotype.Component
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Component
+@RequestMapping("/view")
+class ConnectorsView {
+
+    @GetMapping("/connectors")
+    fun connectors(model: Model): String {
+        addPageInfoToModel(model, "overview")
+        return "views/connectors/connectors"
+    }
+
+    private fun addPageInfoToModel(model: Model, view: String) {
+        model.addAttribute("page", "connectors")
+        model.addAttribute("view", view)
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,13 @@ zeebe:
   clock:
     endpoint: 127.0.0.1:9600/actuator/clock
 
+  connectors:
+    # start Camunda connectors by default
+    enabled: true
+    secrets:
+    #  - name: SLACK_OAUTH_TOKEN
+    #    value: my-slack-oauth-token
+
 spring:
   datasource:
     url: jdbc:h2:mem:zeeqs;DB_CLOSE_DELAY=-1

--- a/src/main/resources/public/js/rest-client.js
+++ b/src/main/resources/public/js/rest-client.js
@@ -1,4 +1,3 @@
-
 function sendRequest(path, type, data) {
 
   return $.ajax({
@@ -23,10 +22,11 @@ function sendDeleteRequest(path, data) {
 }
 
 function sendCreateInstanceRequest(processKey, variables) {
-  return sendPostRequest("processes/" + processKey,  variables);
+  return sendPostRequest("processes/" + processKey, variables);
 }
 
-function sendPublishMessageRequest(messageName, correlationKey, variables, timeToLive, messageId) {
+function sendPublishMessageRequest(messageName, correlationKey, variables,
+    timeToLive, messageId) {
   return sendPostRequest("messages", {
     messageName: messageName,
     correlationKey: correlationKey,
@@ -62,14 +62,15 @@ function deployResources(resources) {
 }
 
 function sendCancelProcessInstanceRequest(processInstanceKey) {
-  return sendDeleteRequest("process-instances/" + processInstanceKey, { });
+  return sendDeleteRequest("process-instances/" + processInstanceKey, {});
 }
 
 function sendSetVariablesRequest(processInstanceKey, scopeKey, variables) {
-  return sendPostRequest("process-instances/" + processInstanceKey + "/variables", {
-    scopeKey: scopeKey,
-    variables: variables
-  });
+  return sendPostRequest(
+      "process-instances/" + processInstanceKey + "/variables", {
+        scopeKey: scopeKey,
+        variables: variables
+      });
 }
 
 function sendCompleteJobRequest(jobKey, variables) {
@@ -100,4 +101,14 @@ function sendUpdateRetriesJobRequest(jobKey, retries) {
 
 function sendResolveIncidentRequest(incidentKey) {
   return sendPostRequest("incidents/" + incidentKey + "/resolve", {});
+}
+
+function sendGetConnectorSecretsRequest() {
+  return sendRequest("connector-secrets/", "GET");
+}
+
+function sendUpdateConnectorSecretsRequest(secrets) {
+  return sendPostRequest("connector-secrets/", {
+    secrets: secrets
+  });
 }

--- a/src/main/resources/public/js/rest-client.js
+++ b/src/main/resources/public/js/rest-client.js
@@ -104,11 +104,11 @@ function sendResolveIncidentRequest(incidentKey) {
 }
 
 function sendGetConnectorSecretsRequest() {
-  return sendRequest("connector-secrets/", "GET");
+  return sendRequest("connector-secrets", "GET");
 }
 
 function sendUpdateConnectorSecretsRequest(secrets) {
-  return sendPostRequest("connector-secrets/", {
+  return sendPostRequest("connector-secrets", {
     secrets: secrets
   });
 }

--- a/src/main/resources/public/js/view-connectors.js
+++ b/src/main/resources/public/js/view-connectors.js
@@ -1,0 +1,96 @@
+// store current connector secrets
+let connectorSecrets = {}
+
+function loadConnectorsView() {
+  loadConnectorSecrets();
+}
+
+function loadConnectorSecrets() {
+
+  sendGetConnectorSecretsRequest().done(response => {
+    let secrets = response.secrets;
+
+    connectorSecrets = secrets;
+
+    $("#connector-secrets-totalCount").text(secrets.length);
+    $("#connector-secrets-table tbody").empty();
+
+    secrets.forEach((secret, index) => {
+
+      let editButtonId = `connector-secrets-edit-${index}`;
+      let deleteButtonId = `connector-secrets-delete-${index}`;
+
+      let row = `
+        <tr>
+          <td>${index + 1}</td>
+          <td>${secret.name}</td>
+          <td>
+            <code>${secret.value}</code>
+          </td>
+          <td>
+            <button id="${editButtonId}" type="button" class="btn btn-sm btn-secondary" title="Edit" data-bs-toggle="modal"
+                          data-bs-target="#edit-connector-secret-modal">
+              <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#pencil"/></svg>
+                Edit
+            </button>
+            
+            <button id="${deleteButtonId}" type="button" class="btn btn-sm btn-secondary" title="Delete">
+              <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#trash"/></svg>
+                Delete
+            </button>
+          </td>
+        </tr>`;
+
+      $("#connector-secrets-table tbody:last-child").append(row);
+
+      $("#" + editButtonId).click(function () {
+        // fill modal
+        $("#edit-connector-secret-name").val(secret.name);
+        $("#edit-connector-secret-value").val(secret.value);
+      });
+
+      $("#" + deleteButtonId).click(function () {
+        // remove the secret from the variable
+        connectorSecrets.splice(index, 1);
+
+        updateConnectSecrets();
+      });
+    })
+  });
+}
+
+function onAddNewConnectorSecret() {
+  let secretNameElement = $("#new-connector-secret-name");
+  let secretValueElement = $("#new-connector-secret-value");
+
+  connectorSecrets.push({
+    "name": secretNameElement.val(),
+    "value": secretValueElement.val()
+  });
+
+  updateConnectSecrets();
+
+  secretNameElement.val('');
+  secretValueElement.val('');
+}
+
+function onEditConnectorSecret() {
+  let secretName = $("#edit-connector-secret-name").val();
+  let secretValue = $("#edit-connector-secret-value").val();
+
+  let index = connectorSecrets.findIndex(item => item.name === secretName);
+
+  connectorSecrets.splice(index, 1, {
+    "name": secretName,
+    "value": secretValue
+  });
+
+  updateConnectSecrets();
+}
+
+function updateConnectSecrets() {
+  sendUpdateConnectorSecretsRequest(connectorSecrets).done(response => {
+    // reload page
+    loadConnectorSecrets();
+  });
+}

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,6 +1,7 @@
 <div class="footer text-center" th:fragment="footer">
 
-  <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 101" id="notifications-toast-container">
+  <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 101"
+       id="notifications-toast-container">
     <!-- notifications -->
   </div>
 
@@ -28,5 +29,6 @@
   <script src="/js/view-process.js" type="text/javascript"></script>
   <script src="/js/view-monitoring.js" type="text/javascript"></script>
   <script src="/js/view-process-instance.js" type="text/javascript"></script>
+  <script src="/js/view-connectors.js" type="text/javascript"></script>
 
 </div>

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -1,4 +1,5 @@
-<nav class="navbar navbar-expand-lg navbar-light bg-light mb-2 border-bottom border-2" th:fragment="navbar">
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-2 border-bottom border-2"
+     th:fragment="navbar">
   <div class="container-fluid">
     <a class="navbar-brand" href="/view/home">
       <img src="/img/logo.png" alt="" width="30" height="24" class="d-inline-block align-text-top">
@@ -10,13 +11,16 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item">
-          <a class="nav-link" th:classappend="${page} == 'deployment' ? active : ''" aria-current="page" href="/view/deployment">Deployment</a>
+          <a class="nav-link" th:classappend="${page} == 'deployment' ? active : ''"
+             aria-current="page" href="/view/deployment">Deployment</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" th:classappend="${page} == 'monitoring' ? active : ''" href="/view/monitoring">Monitoring</a>
+          <a class="nav-link" th:classappend="${page} == 'monitoring' ? active : ''"
+             href="/view/monitoring">Monitoring</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" th:classappend="${page} == 'testing' ? active : ''" href="/view/testing">Testing</a>
+          <a class="nav-link" th:classappend="${page} == 'connectors' ? active : ''"
+             href="/view/connectors">Connectors</a>
         </li>
       </ul>
     </div>

--- a/src/main/resources/templates/views/connectors/connectors.html
+++ b/src/main/resources/templates/views/connectors/connectors.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="fragments/header :: head"></head>
+<body onload="loadConnectorsView();">
+
+<div th:replace="fragments/navbar :: navbar"></div>
+<div
+    th:replace="views/connectors/new-connector-secret-modal.html :: #new-connector-secret-modal"></div>
+<div
+    th:replace="views/connectors/edit-connector-secret-modal.html :: #edit-connector-secret-modal"></div>
+
+<div class="container-fluid">
+
+  <div class="row">
+    <div class="col">
+
+      <ul class="nav nav-tabs" id="deployment-tabs" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button class="nav-link active" id="connector-secrets-tab" data-bs-toggle="tab"
+                  data-bs-target="#connector-secrets" type="button" role="tab"
+                  aria-controls="connector-secrets" aria-selected="true">
+            Connector Secrets
+            <span class="badge bg-light text-dark" id="connector-secrets-totalCount">0</span>
+          </button>
+        </li>
+      </ul>
+
+    </div>
+  </div>
+
+  <div class="container-fluid">
+
+    <div class="tab-content" id="connector-secrets-content">
+      <div class="tab-pane fade show active" id="connector-secrets" role="tabpanel"
+           aria-labelledby="connector-secrets-tab">
+
+        <div class="row">
+          <div class="col">
+
+            <table class="table table-striped table-hover caption-top" id="connector-secrets-table">
+              <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">Secret name</th>
+                <th scope="col">Secret value</th>
+                <th scope="col">
+                  <button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal"
+                          data-bs-target="#new-connector-secret-modal">
+                    <svg class="bi" width="18" height="18" fill="white">
+                      <use xlink:href="/img/bootstrap-icons.svg#key"/>
+                    </svg>
+                    New Secret
+                  </button>
+                </th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td>1</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+              </tr>
+              </tbody>
+            </table>
+
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+</div>
+
+<footer th:replace="fragments/footer :: footer"></footer>
+
+</body>
+</html>

--- a/src/main/resources/templates/views/connectors/edit-connector-secret-modal.html
+++ b/src/main/resources/templates/views/connectors/edit-connector-secret-modal.html
@@ -1,0 +1,39 @@
+<div th:fragment="edit-connector-secret-modal">
+
+  <div class="modal fade" id="edit-connector-secret-modal" tabindex="-1"
+       aria-labelledby="edit-connector-secretModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="edit-connector-secretModal">Edit Connector Secret</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"
+                  aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+
+          <form>
+            <div class="mb-3">
+              <label for="edit-connector-secret-name" class="form-label">Secret name</label>
+              <input class="form-control" id="edit-connector-secret-name" type="text" readonly>
+            </div>
+            <div class="mb-3">
+              <label for="edit-connector-secret-value" class="form-label">Secret value</label>
+              <input class="form-control" id="edit-connector-secret-value" type="text">
+              <div class="form-text">Secrets are not encrypted. You should not use actual secrets
+                from a production environment.
+              </div>
+            </div>
+          </form>
+
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal"
+                  onclick="onEditConnectorSecret();">Update
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/src/main/resources/templates/views/connectors/new-connector-secret-modal.html
+++ b/src/main/resources/templates/views/connectors/new-connector-secret-modal.html
@@ -1,0 +1,39 @@
+<div th:fragment="new-connector-secret-modal">
+
+  <div class="modal fade" id="new-connector-secret-modal" tabindex="-1"
+       aria-labelledby="new-connector-secretModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="new-connector-secretModal">New Connector Secret</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"
+                  aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+
+          <form>
+            <div class="mb-3">
+              <label for="new-connector-secret-name" class="form-label">Secret name</label>
+              <input class="form-control" id="new-connector-secret-name" type="text">
+            </div>
+            <div class="mb-3">
+              <label for="new-connector-secret-value" class="form-label">Secret value</label>
+              <input class="form-control" id="new-connector-secret-value" type="text">
+              <div class="form-text">Secrets are not encrypted. You should not use actual secrets
+                from a production environment.
+              </div>
+            </div>
+          </form>
+
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal"
+                  onclick="onAddNewConnectorSecret();">Add
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>


### PR DESCRIPTION
## Description

Bundles Camunda connectors (version `0.15.0`) into Zeebe-Play. The connectors are started when the application is started.

Add a new database repository to store the connector secrets. Add a new page to the UI to see and modify the secrets.

The connectors can be disabled in the config:

```yaml
zeebe:
  client:
    connectors:
      enabled: false  
```

Initial secrets can be defined in the config:

```yaml
zeebe:
  client:
    connectors:
          secrets:
            - name: SLACK_OAUTH_TOKEN
              value: my-slack-oauth-token  
```

The new REST API could be used to set the connector secrets from outside:

```
curl \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{ "secrets": [{"name": "SLACK_OAUTH_TOKEN", "value": "my-token"}] }' \
  http://localhost:8080/rest/connector-secrets
```

## Related issues

closes #30 