### PR TITLE
feat: Show warning if connector secrets are missing

### DIFF
--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorService.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorService.kt
@@ -4,6 +4,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput
 import io.zeebe.zeeqs.data.repository.ProcessRepository
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Controller
 
@@ -27,6 +28,7 @@ class ConnectorService(
         return referencedSecrets.filterNot { existingSecrets.contains(it) }
     }
 
+    @Cacheable(cacheNames = ["processConnectorSecrets"])
     fun getReferencedConnectorSecrets(processDefinitionKey: Long): List<String> {
         return getBpmnModel(processDefinitionKey)
             ?.getModelElementsByType(ZeebeInput::class.java)

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorService.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorService.kt
@@ -1,0 +1,53 @@
+package org.camunda.community.zeebe.play.connectors
+
+import io.camunda.zeebe.model.bpmn.Bpmn
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput
+import io.zeebe.zeeqs.data.repository.ProcessRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Controller
+
+@Controller
+class ConnectorService(
+    private val processRepository: ProcessRepository,
+    private val connectorSecretRepository: ConnectorSecretRepository
+) {
+
+    // Connector secrets can be references in a string or in placeholder syntax
+    // 1) { x: "secrets.MY_API_KEY"}
+    // 2) "https://" + baseUrl + "/{{secrets.MY_API_KEY}}"
+    private val secretRegex = Regex(pattern = "[\"|{]?secrets\\.(\\w+)[\"|}]?")
+
+    fun getMissingConnectorSecrets(processDefinitionKey: Long): List<String> {
+        val referencedSecrets =
+            getReferencedConnectorSecrets(processDefinitionKey = processDefinitionKey)
+
+        val existingSecrets = connectorSecretRepository.findAll().map { it.name }
+
+        return referencedSecrets.filterNot { existingSecrets.contains(it) }
+    }
+
+    fun getReferencedConnectorSecrets(processDefinitionKey: Long): List<String> {
+        return getBpmnModel(processDefinitionKey)
+            ?.getModelElementsByType(ZeebeInput::class.java)
+            ?.map { it.source }
+            ?.flatMap { findReferencedSecrets(it) }
+            ?.distinct()
+            ?: emptyList()
+    }
+
+    private fun getBpmnModel(processDefinitionKey: Long): BpmnModelInstance? {
+        return processRepository.findByIdOrNull(processDefinitionKey)
+            ?.bpmnXML
+            ?.byteInputStream()
+            ?.let { Bpmn.readModelFromStream(it) }
+    }
+
+    private fun findReferencedSecrets(text: String): List<String> {
+        return secretRegex
+            .findAll(text)
+            .map { it.groupValues[1] }
+            .toList()
+    }
+
+}

--- a/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorSecretsResource.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorSecretsResource.kt
@@ -28,11 +28,16 @@ class ConnectorSecretsResource(
             }
     }
 
-    @RequestMapping(method = [RequestMethod.POST])
+    @RequestMapping(method = [RequestMethod.PUT])
     fun setSecrets(@RequestBody dto: ConnectorSecretsDto) {
         // place all secrets with the request data
         repository.deleteAll()
 
+        addSecrets(dto)
+    }
+
+    @RequestMapping(method = [RequestMethod.POST])
+    fun addSecrets(@RequestBody dto: ConnectorSecretsDto) {
         dto.secrets
             .map {
                 ConnectorSecret(

--- a/src/main/kotlin/org/camunda/community/zeebe/play/rest/ProcessesResource.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/rest/ProcessesResource.kt
@@ -1,18 +1,21 @@
 package org.camunda.community.zeebe.play.rest
 
 import io.camunda.zeebe.client.ZeebeClient
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RestController
+import org.camunda.community.zeebe.play.connectors.ConnectorService
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/rest/processes")
-class ProcessesResource(private val zeebeClient: ZeebeClient) {
+class ProcessesResource(
+    private val zeebeClient: ZeebeClient,
+    private val connectorService: ConnectorService
+) {
 
     @RequestMapping(path = ["/{processKey}"], method = [RequestMethod.POST])
-    fun createInstance(@PathVariable("processKey") processKey: Long, @RequestBody variables: String): Long {
+    fun createInstance(
+        @PathVariable("processKey") processKey: Long,
+        @RequestBody variables: String
+    ): Long {
 
         return zeebeClient.newCreateInstanceCommand()
             .processDefinitionKey(processKey)
@@ -21,5 +24,21 @@ class ProcessesResource(private val zeebeClient: ZeebeClient) {
             .join()
             .processInstanceKey
     }
+
+    @RequestMapping(
+        path = ["/{processKey}/missing-connector-secrets"],
+        method = [RequestMethod.GET]
+    )
+    fun findMissingConnectorSecrets(@PathVariable("processKey") processKey: Long): MissingConnectorSecretsDto {
+        return MissingConnectorSecretsDto(
+            connectorSecretNames = connectorService.getMissingConnectorSecrets(
+                processDefinitionKey = processKey
+            )
+        )
+    }
+
+    data class MissingConnectorSecretsDto(
+        val connectorSecretNames: List<String>
+    )
 
 }

--- a/src/main/resources/public/js/rest-client.js
+++ b/src/main/resources/public/js/rest-client.js
@@ -108,7 +108,13 @@ function sendGetConnectorSecretsRequest() {
 }
 
 function sendUpdateConnectorSecretsRequest(secrets) {
-  return sendPostRequest("connector-secrets", {
+  return sendRequest("connector-secrets", "PUT", {
+    secrets: secrets
+  });
+}
+
+function sendAddConnectorSecretsRequest(secrets) {
+  return sendRequest("connector-secrets", "POST", {
     secrets: secrets
   });
 }

--- a/src/main/resources/public/js/rest-client.js
+++ b/src/main/resources/public/js/rest-client.js
@@ -118,3 +118,8 @@ function sendAddConnectorSecretsRequest(secrets) {
     secrets: secrets
   });
 }
+
+function sendGetMissingConnectSecretsRequest(processKey) {
+  return sendRequest(`processes/${processKey}/missing-connector-secrets`,
+      "GET");
+}

--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -1,4 +1,3 @@
-
 function updatePagination(prefix, perPage, currentPage, totalCount) {
 
   let previousButton = $("#" + prefix + "-pagination-previous-button");
@@ -68,7 +67,8 @@ function showNotificationSuccess(id, content) {
 
   const toastId = "new-toast-" + id;
 
-  const newNotificationToast = '<div id="' + toastId + '" class="toast" role="status" aria-live="polite" aria-atomic="true">'
+  const newNotificationToast = '<div id="' + toastId
+      + '" class="toast" role="status" aria-live="polite" aria-atomic="true">'
       + '<div class="toast-header bg-success text-white">'
       + '<strong class="me-auto">Success</strong>'
       + '<button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>'
@@ -91,7 +91,8 @@ function showNotificationFailure(id, content) {
 
   const toastId = "new-toast-" + id;
 
-  const newNotificationToast = '<div id="' + toastId + '" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-autohide="false">'
+  const newNotificationToast = '<div id="' + toastId
+      + '" class="toast" role="alert" aria-live="assertive" aria-atomic="true" data-bs-autohide="false">'
       + '<div class="toast-header bg-danger text-white">'
       + '<strong class="me-auto">Failure</strong>'
       + '<button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>'
@@ -100,6 +101,30 @@ function showNotificationFailure(id, content) {
       + content
       + '</div>'
       + '</div>';
+
+  let notificationToastContainer = $("#notifications-toast-container");
+
+  notificationToastContainer.append(newNotificationToast);
+
+  let newInstanceToast = $("#" + toastId);
+  let toast = new bootstrap.Toast(newInstanceToast);
+  toast.show();
+}
+
+function showNotificationWarning(id, content) {
+
+  const toastId = "new-toast-" + id;
+
+  const newNotificationToast = `
+    <div id="${toastId}" class="toast" role="warning" aria-live="assertive" aria-atomic="true" data-bs-autohide="false">
+      <div class="toast-header bg-warning text-white">
+        <strong class="me-auto">Warning</strong>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+      <div class="toast-body">
+        ${content}
+      </div>
+    </div>`;
 
   let notificationToastContainer = $("#notifications-toast-container");
 
@@ -146,6 +171,7 @@ function loadView() {
 }
 
 let timer;
+
 function loadViewDebounced(delay = 150) {
   clearTimeout(timer);
   timer = setTimeout(loadView, delay);
@@ -176,7 +202,8 @@ function formatProcessInstanceState(processInstance) {
 
   const error = processInstance.error;
   if (error) {
-    const fillErrorModalAction = 'fillErrorDetailsModal(\'' + processInstance.key + '\');';
+    const fillErrorModalAction = 'fillErrorDetailsModal(\''
+        + processInstance.key + '\');';
     state += ' <span class="badge bg-warning">error</span>'
         + ' <button type="button" class="btn btn-outline-light" data-bs-toggle="modal" data-bs-target="#error-detail-modal" title="Show error details" onclick="'
         + fillErrorModalAction
@@ -303,7 +330,8 @@ function formatBpmnElementInstance(element) {
   const bpmnElement = formatBpmnElement(element.bpmnElementType);
   const action = 'highlightElement(\'' + element.elementId + '\');';
 
-  const highlightButton = '<button type="button" class="btn btn-sm btn-outline-light text-dark" title="Highlight element"  onclick="' + action + '">'
+  const highlightButton = '<button type="button" class="btn btn-sm btn-outline-light text-dark" title="Highlight element"  onclick="'
+      + action + '">'
       + '<svg class="bi" width="18" height="18" fill="black"><use xlink:href="/img/bootstrap-icons.svg#geo-alt"/></svg>'
       + '</button> ';
 
@@ -406,7 +434,8 @@ function publishMessage(messageName, messageCorrelationKey) {
   sendPublishMessageRequest(messageName, messageCorrelationKey)
       .done(messageKey => {
         const toastId = "message-published-" + messageKey;
-        const content = 'New message <code>' + messageKey + '</code> published.';
+        const content = 'New message <code>' + messageKey
+            + '</code> published.';
         showNotificationSuccess(toastId, content);
       })
       .fail(showFailure(
@@ -433,7 +462,8 @@ function publishMessageModal() {
   )
       .done(messageKey => {
         const toastId = "message-published-" + messageKey;
-        const content = 'New message <code>' + messageKey + '</code> published.';
+        const content = 'New message <code>' + messageKey
+            + '</code> published.';
         showNotificationSuccess(toastId, content);
       })
       .fail(showFailure(
@@ -506,7 +536,8 @@ function completeJob(jobKey, variables) {
 
   sendCompleteJobRequest(jobKey, variables)
       .done(key => {
-        showNotificationSuccess(toastId, "Job <code>" + jobKey + "</code> completed.");
+        showNotificationSuccess(toastId,
+            "Job <code>" + jobKey + "</code> completed.");
       })
       .fail(showFailure(toastId,
           "Failed to complete job <code>" + jobKey + "</code>.")
@@ -518,7 +549,8 @@ function failJob(jobKey, retries, errorMessage) {
 
   sendFailJobRequest(jobKey, retries, errorMessage)
       .done(key => {
-        showNotificationSuccess(toastId, "Job <code>" + jobKey + "</code> failed.");
+        showNotificationSuccess(toastId,
+            "Job <code>" + jobKey + "</code> failed.");
       })
       .fail(showFailure(toastId,
           "Failed to fail job <code>" + jobKey + "</code>.")
@@ -530,7 +562,8 @@ function throwErrorJob(jobKey, errorCode, errorMessage) {
 
   sendThrowErrorJobRequest(jobKey, errorCode, errorMessage)
       .done(key => {
-        showNotificationSuccess(toastId, "An error <code>" + errorCode + "</code> was thrown for the job <code>" + jobKey + "</code>.");
+        showNotificationSuccess(toastId, "An error <code>" + errorCode
+            + "</code> was thrown for the job <code>" + jobKey + "</code>.");
       })
       .fail(showFailure(toastId,
           "Failed to throw error for the job <code>" + jobKey + "</code>.")
@@ -570,7 +603,8 @@ function resolveIncident(incidentKey, jobKey) {
   if (jobKey) {
     sendUpdateRetriesJobRequest(jobKey, 1)
         .done(key => {
-          showNotificationSuccess(toastId, "Retries of job <code>" + jobKey + "</code> increase.");
+          showNotificationSuccess(toastId,
+              "Retries of job <code>" + jobKey + "</code> increase.");
 
           resolveIncidentByKey(incidentKey);
         })
@@ -587,7 +621,8 @@ function resolveIncidentByKey(incidentKey) {
   const toastId = "incident-resolve-" + incidentKey;
   sendResolveIncidentRequest(incidentKey)
       .done(key => {
-        showNotificationSuccess(toastId, "Incident <code>" + incidentKey + "</code> resolved.");
+        showNotificationSuccess(toastId,
+            "Incident <code>" + incidentKey + "</code> resolved.");
       })
       .fail(showFailure(toastId,
           "Failed to resolve incident <code>" + incidentKey + "</code>.")
@@ -629,3 +664,36 @@ function fillErrorDetailsModal(processInstanceKey) {
   });
 }
 
+function checkForMissingConnectorSecrets(processKey) {
+  sendGetMissingConnectSecretsRequest(processKey)
+      .done(response => {
+        let connectorSecretNames = response.connectorSecretNames;
+        if (connectorSecretNames.length > 0) {
+
+          let buttonId = "add-missing-connector-secrets";
+
+          showNotificationWarning(
+              "connector-secrets-missing",
+              `Connector secrets are missing. The process references secrets that are not set yet.
+                <div class="mt-2 pt-2 border-top">
+                  <button id="${buttonId}" type="button" class="btn btn-outline-primary btn-sm">Add missing secrets</button>
+                </div>`
+          );
+
+          $("#" + buttonId).click(function () {
+
+            let newSecrets = connectorSecretNames.map(function (name) {
+              return {
+                "name": name,
+                "value": "ENTER_YOUR_SECRET"
+              };
+            });
+
+            sendAddConnectorSecretsRequest(newSecrets).done(response => {
+              // switch to connector secrets page
+              window.location.href = "/view/connectors";
+            });
+          });
+        }
+      });
+}

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -49,7 +49,10 @@ function loadProcessInstanceView() {
         }
 
         if (!bpmnViewIsLoaded) {
-          subscribeToUpdates('processInstanceKey', processInstance.key, () => loadViewDebounced());
+          subscribeToUpdates('processInstanceKey', processInstance.key,
+              () => loadViewDebounced());
+
+          checkForMissingConnectorSecrets(process.key);
 
           const bpmnXML = process.bpmnXML;
           showBpmn(bpmnXML).then(function (r) {
@@ -426,8 +429,10 @@ function addElementCounters(processInstance) {
     }
   });
 
-  const showElementCountersButton = $("#process-instance-show-element-counters");
-  const hideElementCountersButton = $("#process-instance-hide-element-counters");
+  const showElementCountersButton = $(
+      "#process-instance-show-element-counters");
+  const hideElementCountersButton = $(
+      "#process-instance-hide-element-counters");
 
   showElementCountersButton.click(function () {
     isElementCountersViewEnabled = true;
@@ -592,7 +597,8 @@ function loadUserTasksOfProcessInstance() {
 
           const isActiveTask = userTask.state === "CREATED";
           if (isActiveTask) {
-            makeTaskPlayable(elementId, userTask.key, {isUserTask: true, taskForm: userTask.form?.resource});
+            makeTaskPlayable(elementId, userTask.key,
+                {isUserTask: true, taskForm: userTask.form?.resource});
           }
         });
 
@@ -698,7 +704,7 @@ function formatCorrelatedMessages(messageSubscription) {
 
   let correlatedMessagesFormatted = '<div class="row row-cols-1">'
       + '<div class="col">'
-      + '<span class="badge bg-secondary">' + correlatedMessageCount+ '</span>'
+      + '<span class="badge bg-secondary">' + correlatedMessageCount + '</span>'
       + ' <button type="button" class="btn btn-sm btn-outline-light" data-bs-toggle="collapse" href="#'
       + messageSubscriptionCollapseId
       + '" aria-expanded="false" title="Show correlated messages">'

--- a/src/main/resources/public/js/view-process.js
+++ b/src/main/resources/public/js/view-process.js
@@ -21,7 +21,10 @@ function loadProcessView() {
         $("#process-deployment-time").text(process.deployTime);
 
         if (!bpmnViewIsLoaded) {
-          subscribeToUpdates('processKey', processKey, () => loadViewDebounced());
+          subscribeToUpdates('processKey', processKey,
+              () => loadViewDebounced());
+
+          checkForMissingConnectorSecrets(processKey);
 
           const bpmnXML = process.bpmnXML;
           showBpmn(bpmnXML).then(ok => {
@@ -48,13 +51,16 @@ function loadInstancesOfProcess(currentPage) {
   const processKey = getProcessKey();
   instancesOfProcessCurrentPage = currentPage;
 
-  queryInstancesByProcess(processKey, instancesOfProcessPerPage, instancesOfProcessCurrentPage)
+  queryInstancesByProcess(processKey, instancesOfProcessPerPage,
+      instancesOfProcessCurrentPage)
       .done(function (response) {
 
         let process = response.data.process;
         $("#process-instances-active").text(process.activeInstances.totalCount);
-        $("#process-instances-completed").text(process.completedInstances.totalCount);
-        $("#process-instances-terminated").text(process.terminatedInstances.totalCount);
+        $("#process-instances-completed").text(
+            process.completedInstances.totalCount);
+        $("#process-instances-terminated").text(
+            process.terminatedInstances.totalCount);
 
         let processInstances = process.processInstances;
         let totalCount = processInstances.totalCount;
@@ -63,7 +69,8 @@ function loadInstancesOfProcess(currentPage) {
 
         $("#instances-of-process-table tbody").empty();
 
-        const indexOffset = instancesOfProcessCurrentPage * instancesOfProcessPerPage + 1;
+        const indexOffset = instancesOfProcessCurrentPage
+            * instancesOfProcessPerPage + 1;
 
         processInstances.nodes.forEach((processInstance, index) => {
 
@@ -75,13 +82,14 @@ function loadInstancesOfProcess(currentPage) {
           }
 
           $("#instances-of-process-table tbody:last-child").append('<tr>'
-              + '<td>' + (indexOffset + index) +'</td>'
+              + '<td>' + (indexOffset + index) + '</td>'
               + '<td>'
-              + '<a href="/view/process-instance/' + processInstance.key + '">' + processInstance.key + '</a>'
+              + '<a href="/view/process-instance/' + processInstance.key + '">'
+              + processInstance.key + '</a>'
               + '</td>'
-              + '<td>' + processInstance.startTime +'</td>'
-              + '<td>' + endTime +'</td>'
-              + '<td>' + state +'</td>'
+              + '<td>' + processInstance.startTime + '</td>'
+              + '<td>' + endTime + '</td>'
+              + '<td>' + state + '</td>'
               + '</tr>');
         });
 
@@ -90,7 +98,8 @@ function loadInstancesOfProcess(currentPage) {
 }
 
 function updateInstancesOfProcessPagination(totalCount) {
-  updatePagination("instances-of-process", instancesOfProcessPerPage, instancesOfProcessCurrentPage, totalCount);
+  updatePagination("instances-of-process", instancesOfProcessPerPage,
+      instancesOfProcessCurrentPage, totalCount);
 }
 
 function loadInstancesOfProcessFirst() {
@@ -104,6 +113,7 @@ function loadInstancesOfProcessPrevious() {
 function loadInstancesOfProcessNext() {
   loadInstancesOfProcess(instancesOfProcessCurrentPage + 1);
 }
+
 function loadInstancesOfProcessLast() {
   let last = $("#instances-of-process-pagination-last").text() - 1;
   loadInstancesOfProcess(last);
@@ -129,7 +139,8 @@ function createNewProcessInstanceWith(processKey, variables) {
       .done(processInstanceKey => {
 
         const toastId = "new-instance-" + processInstanceKey;
-        const content = 'New process instance <a id="new-instance-toast-link" href="/view/process-instance/' + processInstanceKey + '">' + processInstanceKey + '</a> created.';
+        const content = 'New process instance <a id="new-instance-toast-link" href="/view/process-instance/'
+            + processInstanceKey + '">' + processInstanceKey + '</a> created.';
         showNotificationSuccess(toastId, content);
       })
       .fail(showFailure(
@@ -158,23 +169,29 @@ function loadMessageSubscriptionsOfProcess() {
 
         messageSubscriptions.forEach((messageSubscription, index) => {
 
-          const fillModalAction = 'fillPublishMessageModal(\'' + messageSubscription.messageName  + '\');';
-          let actionButton = '<button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#publish-message-modal" title="Publish message" onclick="'+ fillModalAction + '">'
+          const fillModalAction = 'fillPublishMessageModal(\''
+              + messageSubscription.messageName + '\');';
+          let actionButton = '<button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#publish-message-modal" title="Publish message" onclick="'
+              + fillModalAction + '">'
               + '<svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#envelope"/></svg>'
               + ' Publish Message'
               + '</button>';
 
-          $("#message-subscriptions-of-process-table > tbody:last-child").append('<tr>'
-              + '<td>' + (indexOffset + index) +'</td>'
+          $("#message-subscriptions-of-process-table > tbody:last-child").append(
+              '<tr>'
+              + '<td>' + (indexOffset + index) + '</td>'
               + '<td>' + messageSubscription.key + '</td>'
-              + '<td>' + messageSubscription.messageName +'</td>'
-              + '<td>' + formatBpmnElementInstance(messageSubscription.element) +'</td>'
+              + '<td>' + messageSubscription.messageName + '</td>'
+              + '<td>' + formatBpmnElementInstance(messageSubscription.element)
+              + '</td>'
               + '<td>' + formatCorrelatedMessages(messageSubscription) + '</td>'
-              + '<td>' + actionButton +'</td>'
+              + '<td>' + actionButton + '</td>'
               + '</tr>');
 
-          const clickAction = 'publishMessage(\'' + messageSubscription.messageName + '\');';
-          addPublishMessageButton(messageSubscription.element.elementId, clickAction, fillModalAction);
+          const clickAction = 'publishMessage(\''
+              + messageSubscription.messageName + '\');';
+          addPublishMessageButton(messageSubscription.element.elementId,
+              clickAction, fillModalAction);
         });
       });
 }
@@ -201,23 +218,25 @@ function loadTimersOfProcess() {
           const state = formatTimerState(timer.state);
           const isActiveTimer = timer.state === "CREATED";
 
-          const fillModalAction = 'fillTimeTravelModal(\'' + timer.dueDate  + '\');';
+          const fillModalAction = 'fillTimeTravelModal(\'' + timer.dueDate
+              + '\');';
 
           let actionButton = "";
           if (isActiveTimer) {
-            actionButton = '<button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#time-travel-modal" title="Time travel" onclick="'+ fillModalAction + '">'
+            actionButton = '<button type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#time-travel-modal" title="Time travel" onclick="'
+                + fillModalAction + '">'
                 + '<svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#clock"/></svg>'
                 + ' Time Travel'
                 + '</button>';
           }
 
           $("#timers-of-process-table tbody:last-child").append('<tr>'
-              + '<td>' + (indexOffset + index) +'</td>'
+              + '<td>' + (indexOffset + index) + '</td>'
               + '<td>' + timer.key + '</td>'
-              + '<td>' + formatTimerRepetitions(timer) +'</td>'
-              + '<td>' + timer.dueDate  + '</td>'
-              + '<td>' + formatBpmnElementInstance(timer.element)  + '</td>'
-              + '<td>' + state +'</td>'
+              + '<td>' + formatTimerRepetitions(timer) + '</td>'
+              + '<td>' + timer.dueDate + '</td>'
+              + '<td>' + formatBpmnElementInstance(timer.element) + '</td>'
+              + '<td>' + state + '</td>'
               + '<td>' + actionButton + '</td>'
               + '</tr>');
 
@@ -243,7 +262,8 @@ function loadProcessElementOverview() {
           const completedElementInstancesCount = element.completedElementInstances.totalCount;
           const terminatedElementInstancesCount = element.terminatedElementInstances.totalCount;
 
-          if (activeElementInstancesCount + completedElementInstancesCount + terminatedElementInstancesCount > 0) {
+          if (activeElementInstancesCount + completedElementInstancesCount
+              + terminatedElementInstancesCount > 0) {
             elementCounters[elementId] = {
               active: activeElementInstancesCount,
               completed: completedElementInstancesCount,
@@ -255,7 +275,8 @@ function loadProcessElementOverview() {
         onBpmnElementHover(function (elementId) {
           const counter = elementCounters[elementId];
           if (counter) {
-            showElementCounters(elementId, counter.active, counter.completed, counter.terminated);
+            showElementCounters(elementId, counter.active, counter.completed,
+                counter.terminated);
           }
         });
 

--- a/src/test/kotlin/org/camunda/community/zeebe/play/ConnectorServiceTest.kt
+++ b/src/test/kotlin/org/camunda/community/zeebe/play/ConnectorServiceTest.kt
@@ -1,0 +1,136 @@
+package org.camunda.community.zeebe.play
+
+import io.camunda.zeebe.model.bpmn.Bpmn
+import io.zeebe.zeeqs.data.entity.Process
+import io.zeebe.zeeqs.data.repository.ProcessRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.camunda.community.zeebe.play.connectors.ConnectorSecret
+import org.camunda.community.zeebe.play.connectors.ConnectorSecretRepository
+import org.camunda.community.zeebe.play.connectors.ConnectorService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.Instant
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class ConnectorServiceTest(
+    @Autowired private val connectorService: ConnectorService,
+    @Autowired private val processRepository: ProcessRepository,
+    @Autowired private val connectorSecretRepository: ConnectorSecretRepository
+) {
+
+    private val processDefinitionKey: Long = 10
+
+    private val bpmnModel = Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .serviceTask(
+            "A", {
+                it.zeebeJobType("A")
+                    .zeebeInput("secrets.X", "x")
+            }
+        ).serviceTask(
+            "B",
+            {
+                it.zeebeJobType("B")
+                    .zeebeInputExpression("""{y: "secrets.Y"}""", "y")
+            }
+        )
+        .serviceTask(
+            "C",
+            {
+                it.zeebeJobType("C")
+                    .zeebeInputExpression(
+                        """base + "/key/{{secrets.Z}}" """,
+                        "z"
+                    )
+            }
+        )
+        .done()
+
+    @BeforeEach
+    fun `set up process repository`() {
+        processRepository.save(
+            Process(
+                key = processDefinitionKey,
+                bpmnProcessId = "process",
+                version = 1,
+                bpmnXML = Bpmn.convertToString(
+                    bpmnModel
+                ),
+                deployTime = Instant.now().toEpochMilli(),
+                resourceName = "process.bpmn",
+                checksum = "checksum"
+            )
+        )
+    }
+
+    @AfterEach
+    fun `clean connector secrets repo`() {
+        connectorSecretRepository.deleteAll()
+    }
+
+    @Test
+    fun `should get referenced secrets of process`() {
+        // given
+
+        // when
+        val secrets =
+            connectorService.getReferencedConnectorSecrets(processDefinitionKey)
+
+        // then
+        assertThat(secrets).hasSize(3).contains("X", "Y", "Z")
+    }
+
+    @Test
+    fun `should get all secrets if no secrets are stored`() {
+        // given
+
+        // when
+        val secrets =
+            connectorService.getMissingConnectorSecrets(processDefinitionKey)
+
+        // then
+        assertThat(secrets).hasSize(3).contains("X", "Y", "Z")
+    }
+
+    @Test
+    fun `should get the missing secrets`() {
+        // given
+        connectorSecretRepository.saveAll(
+            listOf(
+                ConnectorSecret(name = "X", value = "xxx"),
+                ConnectorSecret(name = "Z", value = "zzz"),
+            )
+        )
+
+        // when
+        val secrets =
+            connectorService.getMissingConnectorSecrets(processDefinitionKey)
+
+        // then
+        assertThat(secrets).hasSize(1).contains("Y")
+    }
+
+    @Test
+    fun `should get no secrets if all secrets are stored`() {
+        // given
+        connectorSecretRepository.saveAll(
+            listOf(
+                ConnectorSecret(name = "X", value = "xxx"),
+                ConnectorSecret(name = "Y", value = "xxx"),
+                ConnectorSecret(name = "Z", value = "zzz"),
+            )
+        )
+
+        // when
+        val secrets =
+            connectorService.getMissingConnectorSecrets(processDefinitionKey)
+
+        // then
+        assertThat(secrets).isEmpty()
+    }
+}


### PR DESCRIPTION
## Description

Show a warning on the process or process instance page if the process references connector secrets that are not set yet.

The warning contains a button to add the missing secret. By clicking the button, it adds all missing secrets with the value `ENTER_YOUR_SECRET`.

![image](https://user-images.githubusercontent.com/4305769/216627538-0455b772-83c7-40b4-acdd-153a1909e8f2.png)

## Related issues

related to #30 