### PR TITLE
feat: Invoke connectors manually

### DIFF
--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorProperties.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorProperties.kt
@@ -7,11 +7,15 @@ import org.springframework.boot.context.properties.ConstructorBinding
 @ConfigurationProperties("zeebe.connectors")
 data class ConnectorProperties(
     val secrets: List<ConnectorSecretProperty> = emptyList(),
-    val enabled: Boolean = true
+    val mode: ConnectorsMode = ConnectorsMode.PASSIVE
 ) {
 
     data class ConnectorSecretProperty(
         val name: String,
         val value: String
     )
+
+    enum class ConnectorsMode {
+        ACTIVE, PASSIVE
+    }
 }

--- a/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorsResource.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorsResource.kt
@@ -1,14 +1,23 @@
 package org.camunda.community.zeebe.play.rest
 
+import io.camunda.connector.impl.outbound.OutboundConnectorConfiguration
+import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler
+import io.camunda.zeebe.client.ZeebeClient
+import io.camunda.zeebe.client.api.response.ActivatedJob
 import org.camunda.community.zeebe.play.connectors.ConnectorService
+import org.camunda.community.zeebe.play.connectors.ConnectorsSecretProvider
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
+import java.time.Duration
 
 @RestController
 @RequestMapping("/rest/connectors")
 class ConnectorsResource(
-    private val connectorService: ConnectorService
+    private val connectorService: ConnectorService,
+    private val connectorsSecretProvider: ConnectorsSecretProvider,
+    private val zeebeClient: ZeebeClient
 ) {
 
     @RequestMapping(method = [RequestMethod.GET])
@@ -18,6 +27,44 @@ class ConnectorsResource(
                 .findAvailableConnectors()
                 .map { ConnectDto(name = it.name, type = it.type) }
         )
+    }
+
+    @RequestMapping(path = ["/{jobType}/execute/{jobKey}"], method = [RequestMethod.POST])
+    fun executeJob(@PathVariable("jobType") jobType: String, @PathVariable("jobKey") jobKey: Long) {
+        val connectorConfig = (connectorService.findAvailableConnectors()
+            .find { it.type == jobType }
+            ?: throw RuntimeException("No connector found with job type '$jobType'."))
+
+        val jobHandler = ConnectorJobHandler(connectorConfig.function, connectorsSecretProvider)
+
+        findConnectorJob(connectorConfig, jobKey)
+            ?.let { jobHandler.handle(zeebeClient, it) }
+            ?: throw RuntimeException("No job found with key '$jobKey'.")
+    }
+
+    private fun findConnectorJob(
+        connectorConfig: OutboundConnectorConfiguration,
+        jobKey: Long,
+        attempt: Int = 1
+    ): ActivatedJob? {
+        val job = zeebeClient
+            .newActivateJobsCommand()
+            .jobType(connectorConfig.type)
+            .maxJobsToActivate(attempt * 100)
+            .workerName(connectorConfig.name)
+            .fetchVariables(connectorConfig.inputVariables.toList())
+            .timeout(Duration.ofSeconds(1)) // we don't want to block other jobs too long
+            .send()
+            .join()
+            .jobs
+            .find { it.key == jobKey }
+
+        if (job == null && attempt <= 5) {
+            // try again
+            return findConnectorJob(connectorConfig, jobKey, attempt + 1)
+        }
+
+        return job
     }
 
     data class ConnectorsDto(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,8 +24,8 @@ zeebe:
     endpoint: 127.0.0.1:9600/actuator/clock
 
   connectors:
-    # start Camunda connectors by default
-    enabled: true
+    # connector mode options: 'active' (as job workers) / 'passive' (trigger manually in process)
+    mode: passive
     secrets:
     #  - name: SLACK_OAUTH_TOKEN
     #    value: my-slack-oauth-token

--- a/src/main/resources/public/js/rest-client.js
+++ b/src/main/resources/public/js/rest-client.js
@@ -1,62 +1,64 @@
 function sendRequest(path, type, data) {
-
   return $.ajax({
     type: type,
-    url: '/rest/' + path,
+    url: "/rest/" + path,
     data: JSON.stringify(data),
-    contentType: 'application/json; charset=utf-8',
+    contentType: "application/json; charset=utf-8",
     timeout: 5000,
     crossDomain: true,
-  })
-      .done(function (data) {
-        return data;
-      });
+  }).done(function (data) {
+    return data;
+  });
 }
 
 function sendPostRequest(path, data) {
-  return sendRequest(path, 'POST', data);
+  return sendRequest(path, "POST", data);
 }
 
 function sendDeleteRequest(path, data) {
-  return sendRequest(path, 'DELETE', data);
+  return sendRequest(path, "DELETE", data);
 }
 
 function sendGetRequest(path, data) {
-  return sendRequest(path, 'GET', data);
+  return sendRequest(path, "GET", data);
 }
 
 function sendCreateInstanceRequest(processKey, variables) {
   return sendPostRequest("processes/" + processKey, variables);
 }
 
-function sendPublishMessageRequest(messageName, correlationKey, variables,
-    timeToLive, messageId) {
+function sendPublishMessageRequest(
+  messageName,
+  correlationKey,
+  variables,
+  timeToLive,
+  messageId
+) {
   return sendPostRequest("messages", {
     messageName: messageName,
     correlationKey: correlationKey,
     variables: variables,
     timeToLive: timeToLive,
-    messageId: messageId
+    messageId: messageId,
   });
 }
 
 function sendTimeTravelRequestWithDuration(duration) {
   return sendPostRequest("timers", {
-    duration: duration
+    duration: duration,
   });
 }
 
 function sendTimeTravelRequestWithDateTime(dateTime) {
   return sendPostRequest("timers", {
-    dateTime: dateTime
+    dateTime: dateTime,
   });
 }
 
 function deployResources(resources) {
-
   return $.ajax({
-    type: 'POST',
-    url: '/rest/deployments/',
+    type: "POST",
+    url: "/rest/deployments/",
     data: new FormData(resources),
     processData: false,
     contentType: false,
@@ -71,35 +73,37 @@ function sendCancelProcessInstanceRequest(processInstanceKey) {
 
 function sendSetVariablesRequest(processInstanceKey, scopeKey, variables) {
   return sendPostRequest(
-      "process-instances/" + processInstanceKey + "/variables", {
-        scopeKey: scopeKey,
-        variables: variables
-      });
+    "process-instances/" + processInstanceKey + "/variables",
+    {
+      scopeKey: scopeKey,
+      variables: variables,
+    }
+  );
 }
 
 function sendCompleteJobRequest(jobKey, variables) {
   return sendPostRequest("jobs/" + jobKey + "/complete", {
-    variables: variables
+    variables: variables,
   });
 }
 
 function sendFailJobRequest(jobKey, retries, errorMessage) {
   return sendPostRequest("jobs/" + jobKey + "/fail", {
     retries: retries,
-    errorMessage: errorMessage
+    errorMessage: errorMessage,
   });
 }
 
 function sendThrowErrorJobRequest(jobKey, errorCode, errorMessage) {
   return sendPostRequest("jobs/" + jobKey + "/throw-error", {
     errorCode: errorCode,
-    errorMessage: errorMessage
+    errorMessage: errorMessage,
   });
 }
 
 function sendUpdateRetriesJobRequest(jobKey, retries) {
   return sendPostRequest("jobs/" + jobKey + "/update-retries", {
-    retries: retries
+    retries: retries,
   });
 }
 
@@ -113,13 +117,13 @@ function sendGetConnectorSecretsRequest() {
 
 function sendUpdateConnectorSecretsRequest(secrets) {
   return sendRequest("connector-secrets", "PUT", {
-    secrets: secrets
+    secrets: secrets,
   });
 }
 
 function sendAddConnectorSecretsRequest(secrets) {
   return sendRequest("connector-secrets", "POST", {
-    secrets: secrets
+    secrets: secrets,
   });
 }
 
@@ -128,5 +132,9 @@ function sendGetMissingConnectSecretsRequest(processKey) {
 }
 
 function sendGetAvailableConnectorsRequest() {
-  return sendGetRequest(`connectors`)
+  return sendGetRequest(`connectors`);
+}
+
+function sendExecuteConnectorRequest(jobType, jobKey) {
+  return sendPostRequest(`connectors/${jobType}/execute/${jobKey}`);
 }

--- a/src/main/resources/public/js/view-bpmn.js
+++ b/src/main/resources/public/js/view-bpmn.js
@@ -307,6 +307,35 @@ function makeTaskPlayable(elementId, jobKey, { isUserTask, taskForm } = {}) {
   });
 }
 
+function makeConnectorTaskPlayable(elementId, jobKey, jobType) {
+  let buttonId = `connector-execute-${elementId}`;
+
+  let content = `
+      <button id="${buttonId}" type="button" class="btn btn-sm btn-primary" title="Invoke connector">
+        <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#plugin"/></svg>
+      </button>`;
+
+  overlays.add(elementId, "job-marker", {
+    position: {
+      top: -20,
+      left: -20,
+    },
+    html: content,
+  });
+
+  $("#" + buttonId).click(function () {
+    executeConnectorJob(jobType, jobKey);
+  });
+
+  $(`.${buttonId}`).tooltip();
+
+  // We have to remove the tooltip manually when removing the element that triggers it
+  // see https://github.com/twbs/bootstrap/issues/3084#issuecomment-5207780
+  $(`.${buttonId}`).on("click", () => {
+    $(`[data-bs-toggle="tooltip"]`).tooltip("hide");
+  });
+}
+
 function removeTaskPlayableMarker(elementId) {
   overlays.remove({ element: elementId, type: "job-marker" });
 }

--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -601,6 +601,24 @@ function throwErrorJob(jobKey, errorCode, errorMessage) {
       );
 }
 
+function executeConnectorJob(jobType, jobKey) {
+  const toastId = "connector-job-" + jobKey;
+
+  sendExecuteConnectorRequest(jobType, jobKey)
+      .done((key) => {
+        showNotificationSuccess(
+            toastId,
+            `Connector of type <code>${jobType}</code> invoked.`
+        );
+      })
+      .fail(
+          showFailure(
+              toastId,
+              `Failed to invoke connector of type <code>${jobType}</code>.`
+          )
+      );
+}
+
 function fillJobModal(jobKey, type) {
   $("#jobKey-" + type).val(jobKey);
 }

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -778,6 +778,8 @@ function loadJobsOfProcessInstance() {
           let state = formatJobState(job.state);
           const isActiveJob = job.state === "ACTIVATABLE";
 
+          let connectorButtonId = `action-connector-execute-${elementId}`;
+
           let actionButton = '';
           if (isActiveJob) {
             let fillModalAction = function (type) {
@@ -804,23 +806,37 @@ function loadJobsOfProcessInstance() {
                 + '</div>';
           }
 
-          $("#jobs-of-process-instance-table > tbody:last-child").append('<tr>'
-              + '<td>' + (indexOffset + index) + '</td>'
-              + '<td>' + job.key + '</td>'
-              + '<td>' + job.jobType + '</td>'
-              + '<td>' + elementFormatted + '</td>'
-              + '<td>' + job.elementInstance.key + '</td>'
-              + '<td>' + state + '</td>'
-              + '<td>' + actionButton + '</td>'
-              + '</tr>');
+        $("#jobs-of-process-instance-table > tbody:last-child").append('<tr>'
+            + '<td>' + (indexOffset + index) + '</td>'
+            + '<td>' + job.key + '</td>'
+            + '<td>' + job.jobType + '</td>'
+            + '<td>' + elementFormatted + '</td>'
+            + '<td>' + job.elementInstance.key + '</td>'
+            + '<td>' + state + '</td>'
+            + '<td>' + actionButton + '</td>'
+            + '</tr>');
 
-          if (isActiveJob) {
-            makeTaskPlayable(elementId, job.key);
-          }
-        });
+      if (isActiveJob) {
+        // connector are handled differently
+        if (isConnectorJob(job)) {
+          makeConnectorTaskPlayable(elementId, job.key, job.jobType);
+
+          $("#" + connectorButtonId).click(function () {
+            executeConnectorJob(job.jobType, job.key);
+          });
+        } else {
+          makeTaskPlayable(elementId, job.key);
+        }
+      }
+    });
 
         removeTaskPlayableMarkersOfJobs(jobs);
       });
+}
+
+function isConnectorJob(job) {
+  // assuming that a job for a connector starts with this prefix
+  return job.jobType.startsWith("io.camunda:");
 }
 
 function removeTaskPlayableMarkersOfJobs(jobs) {

--- a/src/main/resources/templates/views/home.html
+++ b/src/main/resources/templates/views/home.html
@@ -149,10 +149,15 @@
         </h5>
         <div class="card-body">
           <p class="card-text">
-            A task <span class="bpmn-icon-service-task fs-3"></span> can be defined as a <a
+            Select a task <span class="bpmn-icon-service-task fs-3"></span> of an available <a
               href="https://docs.camunda.io/docs/components/connectors/use-connectors/"
-              target="_blank">connector</a>. If the connector is available, the task gets completed
-            automatically.
+              target="_blank">connector</a> and click on
+            <button type="button" class="btn btn-sm btn-primary">
+              <svg class="bi" width="18" height="18" fill="white">
+                <use xlink:href="/img/bootstrap-icons.svg#plugin"/>
+              </svg>
+            </button>
+            to invoke the connector and complete the task.
           </p>
           <p class="card-text">
             Go to <a href="/view/connectors">connectors</a> and see the available connectors.


### PR DESCRIPTION
## Description

Change the way how connectors are integrated. Instead of running the connectors actively as job workers, the connectors can be invoked manually for a given job (i.e. passive mode). 

Create a new API to invoke a connector for a given job type and job key. 

![image](https://user-images.githubusercontent.com/4305769/217544543-874abee1-bb91-4a11-8c03-e87711d94418.png)

## Related issues

related to #30 