### PR TITLE
fix: handle rewind replay for non-elemental time travel

### DIFF
--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -495,7 +495,7 @@ function publishMessageModal() {
 }
 
 function timeTravel(timeDefinition, elementId) {
-  history.push({ action: "timeTravel", elementId });
+  history.push({ action: "timeTravel", elementId, timeDefinition });
   refreshHistory();
 
   const index = timeDefinition.indexOf("P");

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -213,8 +213,22 @@ async function rewind(task) {
           );
           break;
         case "timeTravel":
-          const timer = await fetchTimerForElement(newId, step.elementId);
-          await sendTimeTravelRequestWithDateTime(timer.dueDate);
+          if (step.elementId) {
+            // we are waiting for a timer of a specific element
+            const timer = await fetchTimerForElement(newId, step.elementId);
+            await sendTimeTravelRequestWithDateTime(timer.dueDate);
+          } else {
+            // general time travel without correlation to an element
+            const index = step.timeDefinition.indexOf("P");
+
+            if (index >= 0) {
+              await sendTimeTravelRequestWithDuration(
+                step.timeDefinition.substring(index)
+              );
+            } else {
+              await sendTimeTravelRequestWithDateTime(step.timeDefinition);
+            }
+          }
           break;
         case "completeJob": {
           const jobKey = await fetchJobKeyForTask(newId, step.task);

--- a/src/main/resources/templates/views/monitoring/process-instances/process-instance.html
+++ b/src/main/resources/templates/views/monitoring/process-instances/process-instance.html
@@ -129,6 +129,7 @@
                 <a
                   id="process-instance-time-travel"
                   class="dropdown-item"
+                  onclick="timeTravelModalElementId = undefined"
                   data-bs-toggle="modal"
                   data-bs-target="#time-travel-modal"
                   href="#"


### PR DESCRIPTION
## Description

Using the general time travel from the Set Variables menu created a history entry that just said "timeTravel" without any element information attached. This caused the replay to fail. With this fix, we replay the actual timeDefinition instead.

This might still produce inconsistent results when using a non-duration timeDefinition, but it should no longer block the replay of the history.

## Related issues

closes #108 