### PR TITLE
fix: replay manual globally scoped variable changes

### DIFF
--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -235,6 +235,10 @@ async function rewind(task) {
           );
           break;
         }
+        case "setVariables": {
+          await sendSetVariablesRequest(newId, newId, step.variables);
+          break;
+        }
         default:
           console.error("Unknown rewind action: " + step.action);
       }
@@ -579,11 +583,17 @@ function fillSetVariablesModal(scopeKey, variableName, variableValue) {
 
 function setVariablesModal() {
   let scope = $("#variablesScope").val();
+  let variables = $("#updatedVariables").val();
+
   if (scope === "global") {
     scope = getProcessInstanceKey();
-  }
 
-  let variables = $("#updatedVariables").val();
+    history.push({
+      action: "setVariables",
+      variables,
+    });
+    refreshHistory();
+  }
 
   sendSetVariablesRequest(getProcessInstanceKey(), scope, variables)
     .done((key) => {


### PR DESCRIPTION
## Description

This change replays the action of the "Set Variables" modal. This only works if the scope is set to global, because figuring out the scope key for non-globally scoped variables and correlating this with the equivalent scope key in the new instance is kinda tricky.

But I think globally scoped changes are the majority of use-cases for the "Set Variables" modal, so this should already make support much better.

## Related issues

closes #110 