### PR TITLE
feat: Cancel process instance on rewind

### DIFF
--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -5,6 +5,8 @@ var isElementCountersViewEnabled = false;
 
 const jobKeyToElementIdMapping = {};
 
+let processInstance;
+
 function getProcessInstanceKey() {
   return $("#process-instance-page-key").text();
 }
@@ -49,7 +51,7 @@ function loadProcessInstanceView() {
   const processInstanceKey = getProcessInstanceKey();
 
   queryProcessInstance(processInstanceKey).done(function (response) {
-    let processInstance = response.data.processInstance;
+    processInstance = response.data.processInstance;
     let process = processInstance.process;
 
     currentProcessKey = process.key;
@@ -159,6 +161,11 @@ async function rewind(task) {
 
   let newId, newHistory;
   try {
+    // cancel the current process instance before creating a new instance
+    if (processInstance.state === "ACTIVATED") {
+      await sendCancelProcessInstanceRequest(processInstance.key);
+    }
+
     const startEvent = await getStartEvent(getProcessInstanceKey());
 
     if (!startEvent.eventDefinitions) {


### PR DESCRIPTION
## Description

When a user clicks on rewind, it terminates the current process instance. 

Assumption: the user doesn't want to continue the process instance after clicking on rewind. Instead, the user wants to play with the new process instance at the selected element.

By terminating the current process instance, we solve some issues with open message subscriptions.

## Related issues

related to #104 