### PR TITLE
feat: Show previous response before completing the job

### DIFF
--- a/src/main/resources/public/js/view-bpmn.js
+++ b/src/main/resources/public/js/view-bpmn.js
@@ -225,36 +225,44 @@ function makeTaskPlayable(elementId, jobKey, { isUserTask, taskForm } = {}) {
   const cachedResponse = localStorage.getItem(
     "jobCompletion " + getBpmnProcessId() + " " + elementId
   );
-  if (
-    !taskForm &&
-    cachedResponse &&
-    Object.keys(JSON.parse(cachedResponse)).length > 0
-  ) {
+  const hasCachedResponse =
+    cachedResponse && Object.keys(JSON.parse(cachedResponse)).length > 0;
+
+  if (!taskForm && hasCachedResponse) {
     actions.push({
-      icon: '<svg class="bi" width="18" height="18"><use xlink:href="/img/bootstrap-icons.svg#robot"/></svg>',
+      icon: '<svg class="bi" width="18" height="18"><use xlink:href="/img/bootstrap-icons.svg#filetype-json"/></svg>',
       text: "Use previous response",
-      action: `completeJob(${jobKey}, ${JSON.stringify(cachedResponse)});`,
+      action: `showJobCompleteModal(${jobKey}, "complete", ${JSON.stringify(
+        cachedResponse
+      )})`,
     });
   }
 
-  actions.push({
-    icon: '<svg class="bi" width="18" height="18"><use xlink:href="/img/bootstrap-icons.svg#check"/></svg>',
-    text: "Complete Job",
-    action: `completeJob(${jobKey}, "{}");`,
-  });
+  if (isUserTask || !hasCachedResponse) {
+    actions.push({
+      icon: '<svg class="bi" width="18" height="18"><use xlink:href="/img/bootstrap-icons.svg#check"/></svg>',
+      text: "Complete Job",
+      action: `completeJob(${jobKey}, "{}");`,
+    });
+  }
 
-  if (!taskForm) {
+  if (!taskForm && !hasCachedResponse) {
     actions.push({
       icon: '<svg class="bi" width="18" height="18"><use xlink:href="/img/bootstrap-icons.svg#filetype-json"/></svg>',
       text: "Complete with variables",
       modalTarget: "#complete-job-modal",
       action: fillModalAction("complete"),
     });
+
+    if (!isUserTask) {
+      actions.push(
+        {} // DIVIDER
+      );
+    }
   }
 
   if (!isUserTask) {
     actions.push(
-      {}, // DIVIDER
       {
         icon: '<svg class="bi" width="18" height="18"><use xlink:href="/img/bootstrap-icons.svg#x"/></svg>',
         text: "Fail",
@@ -270,11 +278,13 @@ function makeTaskPlayable(elementId, jobKey, { isUserTask, taskForm } = {}) {
     );
   }
 
-  let content =
-    '<div class="btn-group">' +
-    `<button type="button" class="btn btn-sm btn-primary overlay-button completeButton-${jobKey}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="${actions[0].text}" onclick='${actions[0].action}'>` +
-    actions[0].icon +
-    "</button>";
+  let content = `
+    <div class="btn-group">
+      <button type="button" class="btn btn-sm btn-primary overlay-button completeButton-${jobKey}" 
+        data-bs-toggle="tooltip" data-bs-placement="bottom" 
+        title="${actions[0].text}" onclick='${actions[0].action}'>
+        ${actions[0].icon} 
+      </button>`;
 
   if (actions.length > 1) {
     // add a dropdown

--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -650,14 +650,19 @@ function fillJobModal(jobKey, type) {
   $("#jobKey-" + type).val(jobKey);
 }
 
+function showJobCompleteModal(jobKey, type, variables) {
+  $("#jobKey-" + type).val(jobKey);
+  $("#jobVariables").val(variables);
+
+  $("#complete-job-modal").modal("show");
+}
+
 function completeJobModal() {
   const jobKey = $("#jobKey-complete").val();
   const jobVariables = $("#jobVariables").val();
 
   completeJob(jobKey, jobVariables);
-
-  // reset modal
-  $("#jobVariables").val("{}");
+  resetJobModal();
 }
 
 function failJobModal() {
@@ -666,10 +671,7 @@ function failJobModal() {
   const errorMessage = $("#jobErrorMessage").val();
 
   failJob(jobKey, retries, errorMessage);
-
-  // reset modal
-  $("#jobRetries").val("0");
-  $("#jobErrorMessage").val("");
+  resetJobModal();
 }
 
 function throwErrorJobModal() {
@@ -678,8 +680,13 @@ function throwErrorJobModal() {
   const errorMessage = $("#job-throw-error-errorMessage").val();
 
   throwErrorJob(jobKey, errorCode, errorMessage);
+  resetJobModal();
+}
 
-  // reset modal
+function resetJobModal() {
+  $("#jobVariables").val("{}");
+  $("#jobRetries").val("0");
+  $("#jobErrorMessage").val("");
   $("#jobErrorCode").val("");
   $("#job-throw-error-errorMessage").val("");
 }

--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -655,6 +655,9 @@ function completeJobModal() {
   const jobVariables = $("#jobVariables").val();
 
   completeJob(jobKey, jobVariables);
+
+  // reset modal
+  $("#jobVariables").val("{}");
 }
 
 function failJobModal() {
@@ -663,6 +666,10 @@ function failJobModal() {
   const errorMessage = $("#jobErrorMessage").val();
 
   failJob(jobKey, retries, errorMessage);
+
+  // reset modal
+  $("#jobRetries").val("0");
+  $("#jobErrorMessage").val("");
 }
 
 function throwErrorJobModal() {
@@ -671,6 +678,10 @@ function throwErrorJobModal() {
   const errorMessage = $("#job-throw-error-errorMessage").val();
 
   throwErrorJob(jobKey, errorCode, errorMessage);
+
+  // reset modal
+  $("#jobErrorCode").val("");
+  $("#job-throw-error-errorMessage").val("");
 }
 
 function resolveIncident(incidentKey, jobKey) {

--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -647,10 +647,14 @@ function executeConnectorJob(jobType, jobKey) {
 }
 
 function fillJobModal(jobKey, type) {
+  resetJobModal();
+
   $("#jobKey-" + type).val(jobKey);
 }
 
 function showJobCompleteModal(jobKey, type, variables) {
+  resetJobModal();
+
   $("#jobKey-" + type).val(jobKey);
   $("#jobVariables").val(variables);
 
@@ -662,7 +666,6 @@ function completeJobModal() {
   const jobVariables = $("#jobVariables").val();
 
   completeJob(jobKey, jobVariables);
-  resetJobModal();
 }
 
 function failJobModal() {
@@ -671,7 +674,6 @@ function failJobModal() {
   const errorMessage = $("#jobErrorMessage").val();
 
   failJob(jobKey, retries, errorMessage);
-  resetJobModal();
 }
 
 function throwErrorJobModal() {
@@ -680,7 +682,6 @@ function throwErrorJobModal() {
   const errorMessage = $("#job-throw-error-errorMessage").val();
 
   throwErrorJob(jobKey, errorCode, errorMessage);
-  resetJobModal();
 }
 
 function resetJobModal() {

--- a/src/main/resources/templates/views/modals/complete-job-modal.html
+++ b/src/main/resources/templates/views/modals/complete-job-modal.html
@@ -1,20 +1,20 @@
 <div th:fragment="complete-job-modal">
   <div
-    class="modal fade"
-    id="complete-job-modal"
-    tabindex="-1"
-    aria-labelledby="completeJobModalLabel"
-    aria-hidden="true"
+      class="modal fade"
+      id="complete-job-modal"
+      tabindex="-1"
+      aria-labelledby="completeJobModalLabel"
+      aria-hidden="true"
   >
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="completeJobModal">Complete Job</h5>
           <button
-            type="button"
-            class="btn-close"
-            data-bs-dismiss="modal"
-            aria-label="Close"
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Close"
           ></button>
         </div>
         <div class="modal-body">
@@ -22,16 +22,16 @@
             <div class="mb-3">
               <label for="jobKey-complete" class="form-label">Job Key</label>
               <input
-                type="text"
-                class="form-control"
-                id="jobKey-complete"
-                readonly
+                  type="text"
+                  class="form-control"
+                  id="jobKey-complete"
+                  readonly
               />
             </div>
 
             <div class="mb-3">
               <label for="jobVariables" class="form-label"
-                >Variables (JSON)</label
+              >Variables (JSON)</label
               >
               <textarea class="form-control" id="jobVariables" rows="3">
 {}</textarea
@@ -39,22 +39,31 @@
             </div>
           </form>
         </div>
-        <div class="modal-footer">
+        <div class="modal-footer justify-content-between">
           <button
-            type="button"
-            class="btn btn-secondary"
-            data-bs-dismiss="modal"
+              type="button"
+              class="btn btn-light"
+              onclick="resetJobModal();"
           >
-            Close
+            Reset
           </button>
-          <button
-            type="button"
-            class="btn btn-primary"
-            data-bs-dismiss="modal"
-            onclick="completeJobModal();"
-          >
-            Complete
-          </button>
+          <div>
+            <button
+                type="button"
+                class="btn btn-secondary"
+                data-bs-dismiss="modal"
+            >
+              Close
+            </button>
+            <button
+                type="button"
+                class="btn btn-primary"
+                data-bs-dismiss="modal"
+                onclick="completeJobModal();"
+            >
+              Complete
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/views/modals/complete-job-modal.html
+++ b/src/main/resources/templates/views/modals/complete-job-modal.html
@@ -1,20 +1,20 @@
 <div th:fragment="complete-job-modal">
   <div
-      class="modal fade"
-      id="complete-job-modal"
-      tabindex="-1"
-      aria-labelledby="completeJobModalLabel"
-      aria-hidden="true"
+    class="modal fade"
+    id="complete-job-modal"
+    tabindex="-1"
+    aria-labelledby="completeJobModalLabel"
+    aria-hidden="true"
   >
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="completeJobModal">Complete Job</h5>
           <button
-              type="button"
-              class="btn-close"
-              data-bs-dismiss="modal"
-              aria-label="Close"
+            type="button"
+            class="btn-close"
+            data-bs-dismiss="modal"
+            aria-label="Close"
           ></button>
         </div>
         <div class="modal-body">
@@ -22,16 +22,16 @@
             <div class="mb-3">
               <label for="jobKey-complete" class="form-label">Job Key</label>
               <input
-                  type="text"
-                  class="form-control"
-                  id="jobKey-complete"
-                  readonly
+                type="text"
+                class="form-control"
+                id="jobKey-complete"
+                readonly
               />
             </div>
 
             <div class="mb-3">
               <label for="jobVariables" class="form-label"
-              >Variables (JSON)</label
+                >Variables (JSON)</label
               >
               <textarea class="form-control" id="jobVariables" rows="3">
 {}</textarea
@@ -41,25 +41,25 @@
         </div>
         <div class="modal-footer justify-content-between">
           <button
-              type="button"
-              class="btn btn-light"
-              onclick="resetJobModal();"
+            type="button"
+            class="btn btn-light"
+            onclick="resetJobModal();"
           >
             Reset
           </button>
           <div>
             <button
-                type="button"
-                class="btn btn-secondary"
-                data-bs-dismiss="modal"
+              type="button"
+              class="btn btn-secondary"
+              data-bs-dismiss="modal"
             >
               Close
             </button>
             <button
-                type="button"
-                class="btn btn-primary"
-                data-bs-dismiss="modal"
-                onclick="completeJobModal();"
+              type="button"
+              class="btn btn-primary"
+              data-bs-dismiss="modal"
+              onclick="completeJobModal();"
             >
               Complete
             </button>


### PR DESCRIPTION
## Description

Change the primary action of jobs with cached responses. Instead of completing the job immediately with the previous response, open the complete job modal with the previous response.

Clear the job modal after submitting it. 

## Related issues
