### PR TITLE
fix: apply incident resolution when replaying actions for rewind

### DIFF
--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -674,6 +674,13 @@ function throwErrorJobModal() {
 }
 
 function resolveIncident(incidentKey, jobKey) {
+  const task = jobKeyToElementIdMapping[jobKey];
+  history.push({
+    action: "resolveIncident",
+    task,
+  });
+  refreshHistory();
+
   const toastId = "job-update-retries-" + jobKey;
 
   if (jobKey) {

--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -674,10 +674,11 @@ function throwErrorJobModal() {
 }
 
 function resolveIncident(incidentKey, jobKey) {
-  const task = jobKeyToElementIdMapping[jobKey];
+  const task = incidentKeyToElementIdMapping[incidentKey];
   history.push({
     action: "resolveIncident",
     task,
+    hasJob: Boolean(jobKey),
   });
   refreshHistory();
 


### PR DESCRIPTION
## Description

* Applies the `resolveIncident` action when replaying the process instance

## Related issues

closes #118 