### PR TITLE
deps: dump connector-runtime from 0.15.0 to 0.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>zeebe-play</artifactId>
@@ -13,7 +15,7 @@
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
     <version>1.4.1</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <properties>
@@ -25,7 +27,7 @@
     <eze.version>1.1.0</eze.version>
     <hazelcast.version>1.2.1</hazelcast.version>
     <spring-zeebe.version>8.1.16</spring-zeebe.version>
-    <camunda-connector-bundle.version>0.15.0</camunda-connector-bundle.version>
+    <camunda-connector-bundle.version>0.16.0</camunda-connector-bundle.version>
     <camunda-connector-sdk.version>0.6.0</camunda-connector-sdk.version>
 
     <kotlin.version>1.8.10</kotlin.version>
@@ -452,7 +454,7 @@
         <version>3.2.1</version>
         <configuration>
           <rules>
-            <dependencyConvergence />
+            <dependencyConvergence/>
           </rules>
           <skip>${skip.enforcer-plugin}</skip>
         </configuration>


### PR DESCRIPTION
## Description

Dump `connector-runtime-bundle` from `0.15.0` to `0.16.0`

## Related issues
 
