### PR TITLE
fix: Correct typo in incident retry popup

### DIFF
--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -715,7 +715,7 @@ function resolveIncident(incidentKey, jobKey) {
       .done((key) => {
         showNotificationSuccess(
           toastId,
-          "Retries of job <code>" + jobKey + "</code> increase."
+          "Retries of job <code>" + jobKey + "</code> increased."
         );
 
         resolveIncidentByKey(incidentKey);


### PR DESCRIPTION
## Description

Fixes a typo in the incident retry popup.

## Related issues

closes #126