### PR TITLE
fix: Align the actions in the job tab with the diagram

### DIFF
--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -991,7 +991,16 @@ function loadJobsOfProcessInstance() {
       let jobThrowErrorButtonId = `job-throw-error-${job.key}`;
 
       if (isActiveJob) {
-        actionButton = `
+        if (isConnectorJob(job)) {
+          // a job for a connector can only be invoked
+          actionButton = `
+            <button id="${connectorButtonId}" type="button" class="btn btn-sm btn-primary">
+              <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#plugin"/></svg>
+              Invoke
+            </button>`;
+        } else {
+          // show all actions for a regular job
+          actionButton = `
           <div class="btn-group">
             <button id="${jobCompleteButtonId}" type="button" class="btn btn-sm btn-primary overlay-button">
               <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#check"/></svg>
@@ -1013,6 +1022,7 @@ function loadJobsOfProcessInstance() {
               </li>
             </ul>
           </div>`;
+        }
       }
 
       $("#jobs-of-process-instance-table > tbody:last-child").append(`
@@ -1027,13 +1037,13 @@ function loadJobsOfProcessInstance() {
           </tr>`);
 
       if (isActiveJob) {
-        // connector are handled differently
         if (isConnectorJob(job)) {
-          makeConnectorTaskPlayable(elementId, job.key, job.jobType);
-
+          // bind action for connector button
           $("#" + connectorButtonId).click(function () {
             executeConnectorJob(job.jobType, job.key);
           });
+
+          makeConnectorTaskPlayable(elementId, job.key, job.jobType);
         } else {
           // bind actions for job buttons
           $("#" + jobCompleteButtonId).click(function () {

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -986,33 +986,27 @@ function loadJobsOfProcessInstance() {
       let connectorButtonId = `action-connector-execute-${elementId}`;
 
       let actionButton = "";
-      let completeJobButtonId = `complete-job-${job.key}`;
+      let jobCompleteButtonId = `job-complete-${job.key}`;
+      let jobFailButtonId = `job-fail-${job.key}`;
+      let jobThrowErrorButtonId = `job-throw-error-${job.key}`;
 
       if (isActiveJob) {
-        let fillModalAction = function (type) {
-          return `fillJobModal(${job.key}, '${type}');`;
-        };
-
         actionButton = `
           <div class="btn-group">
-            <button id="${completeJobButtonId}" type="button" class="btn btn-sm btn-primary overlay-button">
+            <button id="${jobCompleteButtonId}" type="button" class="btn btn-sm btn-primary overlay-button">
               <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#check"/></svg>
               Complete
             </button>
             <button type="button" class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false"><span class="visually-hidden">Toggle Dropdown</span></button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#fail-job-modal" href="#" onclick="${fillModalAction(
-                    "fail"
-                  )}">
+                  <a id="${jobFailButtonId}" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#fail-job-modal" href="#">
                     <svg class="bi" width="18" height="18" fill="black"><use xlink:href="/img/bootstrap-icons.svg#x"/></svg>
                   Fail
                 </a>
               </li>
               <li>
-                <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#throw-error-job-modal" href="#" onclick="${fillModalAction(
-                  "throw-error"
-                )}">
+                <a id="${jobThrowErrorButtonId}" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#throw-error-job-modal" href="#">
                   <svg class="bi" width="18" height="18" fill="black"><use xlink:href="/img/bootstrap-icons.svg#lightning"/></svg>
                   Throw Error
                 </a>
@@ -1056,8 +1050,8 @@ function loadJobsOfProcessInstance() {
             executeConnectorJob(job.jobType, job.key);
           });
         } else {
-          // bind action for completing the job
-          $("#" + completeJobButtonId).click(function () {
+          // bind actions for job buttons
+          $("#" + jobCompleteButtonId).click(function () {
             const cachedResponse = localStorage.getItem(
               "jobCompletion " + getBpmnProcessId() + " " + elementId
             );
@@ -1066,6 +1060,14 @@ function loadJobsOfProcessInstance() {
               jobVariables = {};
             }
             showJobCompleteModal(job.key, "complete", jobVariables);
+          });
+
+          $("#" + jobFailButtonId).click(function () {
+            fillJobModal(job.key, "fail");
+          });
+
+          $("#" + jobThrowErrorButtonId).click(function () {
+            fillJobModal(job.key, "throw-error");
           });
 
           makeTaskPlayable(elementId, job.key);

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -1015,31 +1015,16 @@ function loadJobsOfProcessInstance() {
           </div>`;
       }
 
-      $("#jobs-of-process-instance-table > tbody:last-child").append(
-        "<tr>" +
-          "<td>" +
-          (indexOffset + index) +
-          "</td>" +
-          "<td>" +
-          job.key +
-          "</td>" +
-          "<td>" +
-          job.jobType +
-          "</td>" +
-          "<td>" +
-          elementFormatted +
-          "</td>" +
-          "<td>" +
-          job.elementInstance.key +
-          "</td>" +
-          "<td>" +
-          state +
-          "</td>" +
-          "<td>" +
-          actionButton +
-          "</td>" +
-          "</tr>"
-      );
+      $("#jobs-of-process-instance-table > tbody:last-child").append(`
+        <tr>
+          <td>${indexOffset + index}</td>
+          <td>${job.key}</td>
+          <td>${job.jobType}</td>
+          <td>${elementFormatted}</td>
+          <td>${job.elementInstance.key}</td>
+          <td>${state}</td>
+          <td>${actionButton}</td>
+          </tr>`);
 
       if (isActiveJob) {
         // connector are handled differently

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -986,35 +986,39 @@ function loadJobsOfProcessInstance() {
       let connectorButtonId = `action-connector-execute-${elementId}`;
 
       let actionButton = "";
+      let completeJobButtonId = `complete-job-${job.key}`;
+
       if (isActiveJob) {
         let fillModalAction = function (type) {
-          return "fillJobModal('" + job.key + "', '" + type + "');";
+          return `fillJobModal(${job.key}, '${type}');`;
         };
 
-        actionButton =
-          '<div class="btn-group">' +
-          '<button type="button" class="btn btn-sm btn-primary overlay-button" data-bs-toggle="modal" data-bs-target="#complete-job-modal" onclick="' +
-          fillModalAction("complete") +
-          '">' +
-          '<svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#check"/></svg>' +
-          " Complete" +
-          "</button>" +
-          '<button type="button" class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false"><span class="visually-hidden">Toggle Dropdown</span></button>' +
-          '<ul class="dropdown-menu">' +
-          '<li><a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#fail-job-modal" href="#" onclick="' +
-          fillModalAction("fail") +
-          '">' +
-          '<svg class="bi" width="18" height="18" fill="black"><use xlink:href="/img/bootstrap-icons.svg#x"/></svg>' +
-          " Fail" +
-          "</a></li>" +
-          '<li><a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#throw-error-job-modal" href="#" onclick="' +
-          fillModalAction("throw-error") +
-          '">' +
-          '<svg class="bi" width="18" height="18" fill="black"><use xlink:href="/img/bootstrap-icons.svg#lightning"/></svg>' +
-          " Throw Error" +
-          "</a></li>" +
-          "</ul>" +
-          "</div>";
+        actionButton = `
+          <div class="btn-group">
+            <button id="${completeJobButtonId}" type="button" class="btn btn-sm btn-primary overlay-button">
+              <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#check"/></svg>
+              Complete
+            </button>
+            <button type="button" class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false"><span class="visually-hidden">Toggle Dropdown</span></button>
+              <ul class="dropdown-menu">
+                <li>
+                  <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#fail-job-modal" href="#" onclick="${fillModalAction(
+                    "fail"
+                  )}">
+                    <svg class="bi" width="18" height="18" fill="black"><use xlink:href="/img/bootstrap-icons.svg#x"/></svg>
+                  Fail
+                </a>
+              </li>
+              <li>
+                <a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#throw-error-job-modal" href="#" onclick="${fillModalAction(
+                  "throw-error"
+                )}">
+                  <svg class="bi" width="18" height="18" fill="black"><use xlink:href="/img/bootstrap-icons.svg#lightning"/></svg>
+                  Throw Error
+                </a>
+              </li>
+            </ul>
+          </div>`;
       }
 
       $("#jobs-of-process-instance-table > tbody:last-child").append(
@@ -1052,6 +1056,18 @@ function loadJobsOfProcessInstance() {
             executeConnectorJob(job.jobType, job.key);
           });
         } else {
+          // bind action for completing the job
+          $("#" + completeJobButtonId).click(function () {
+            const cachedResponse = localStorage.getItem(
+              "jobCompletion " + getBpmnProcessId() + " " + elementId
+            );
+            let jobVariables = cachedResponse;
+            if (!cachedResponse) {
+              jobVariables = {};
+            }
+            showJobCompleteModal(job.key, "complete", jobVariables);
+          });
+
           makeTaskPlayable(elementId, job.key);
         }
       }


### PR DESCRIPTION
## Description

Show the same actions on the job action as on the diagram. 

- when completing a job, fill the variable field with the previous response 
- if a job is based on a connector, it can only be invoked but not completed/failed/error-thrown  

## Related issues

closes #122 