### PR TITLE
fix: Can't invoke connector on the diagram

### DIFF
--- a/src/main/resources/public/js/view-bpmn.js
+++ b/src/main/resources/public/js/view-bpmn.js
@@ -350,7 +350,7 @@ function makeTaskPlayable(elementId, jobKey, { isUserTask, taskForm } = {}) {
 }
 
 function makeConnectorTaskPlayable(elementId, jobKey, jobType) {
-  let buttonId = `connector-execute-${elementId}`;
+  let buttonId = `connector-execute-${jobKey}`;
 
   let content = `
       <button id="${buttonId}" type="button" class="btn btn-sm btn-primary" title="Invoke connector">
@@ -369,11 +369,11 @@ function makeConnectorTaskPlayable(elementId, jobKey, jobType) {
     executeConnectorJob(jobType, jobKey);
   });
 
-  $(`.${buttonId}`).tooltip();
+  $("#" + buttonId).tooltip();
 
   // We have to remove the tooltip manually when removing the element that triggers it
   // see https://github.com/twbs/bootstrap/issues/3084#issuecomment-5207780
-  $(`.${buttonId}`).on("click", () => {
+  $("#" + buttonId).on("click", () => {
     $(`[data-bs-toggle="tooltip"]`).tooltip("hide");
   });
 }

--- a/src/main/resources/public/js/view-bpmn.js
+++ b/src/main/resources/public/js/view-bpmn.js
@@ -296,9 +296,11 @@ function makeTaskPlayable(elementId, jobKey, { isUserTask, taskForm } = {}) {
     );
   }
 
+  let buttonId = `complete-job-button-${jobKey}`;
+
   let content = `
     <div class="btn-group">
-      <button type="button" class="btn btn-sm btn-primary overlay-button completeButton-${jobKey}" 
+      <button id="${buttonId}" type="button" class="btn btn-sm btn-primary overlay-button" 
         data-bs-toggle="tooltip" data-bs-placement="bottom" 
         title="${actions[0].text}" onclick='${actions[0].action}'>
         ${actions[0].icon} 
@@ -332,7 +334,8 @@ function makeTaskPlayable(elementId, jobKey, { isUserTask, taskForm } = {}) {
 
   content += "</div>";
 
-  overlays.add(elementId, "job-marker", {
+  let overlayType = isUserTask ? "user-task-action" : "job-action";
+  overlays.add(elementId, overlayType, {
     position: {
       top: -20,
       left: -40,
@@ -340,11 +343,12 @@ function makeTaskPlayable(elementId, jobKey, { isUserTask, taskForm } = {}) {
     html: content,
   });
 
-  $(`.completeButton-${jobKey}`).tooltip();
+  const buttonElement = $("#" + buttonId);
+  buttonElement.tooltip();
 
   // We have to remove the tooltip manually when removing the element that triggers it
   // see https://github.com/twbs/bootstrap/issues/3084#issuecomment-5207780
-  $(`.completeButton-${jobKey}`).on("click", () => {
+  buttonElement.on("click", () => {
     $(`[data-bs-toggle="tooltip"]`).tooltip("hide");
   });
 }
@@ -357,7 +361,7 @@ function makeConnectorTaskPlayable(elementId, jobKey, jobType) {
         <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#plugin"/></svg>
       </button>`;
 
-  overlays.add(elementId, "job-marker", {
+  overlays.add(elementId, "connector-action", {
     position: {
       top: -20,
       left: -20,
@@ -365,21 +369,30 @@ function makeConnectorTaskPlayable(elementId, jobKey, jobType) {
     html: content,
   });
 
-  $("#" + buttonId).click(function () {
+  const buttonElement = $("#" + buttonId);
+  buttonElement.click(function () {
     executeConnectorJob(jobType, jobKey);
   });
 
-  $("#" + buttonId).tooltip();
+  buttonElement.tooltip();
 
   // We have to remove the tooltip manually when removing the element that triggers it
   // see https://github.com/twbs/bootstrap/issues/3084#issuecomment-5207780
-  $("#" + buttonId).on("click", () => {
+  buttonElement.on("click", () => {
     $(`[data-bs-toggle="tooltip"]`).tooltip("hide");
   });
 }
 
-function removeTaskPlayableMarker(elementId) {
-  overlays.remove({ element: elementId, type: "job-marker" });
+function removeAllUserTaskActionMarkers() {
+  overlays.remove({ type: "user-task-action" });
+}
+
+function removeAllJobActionMarkers() {
+  overlays.remove({ type: "job-action" });
+}
+
+function removeAllConnectorActionMarkers() {
+  overlays.remove({ type: "connector-action" });
 }
 
 function addResolveIncidentButton(elementId, action) {

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -973,6 +973,10 @@ function loadJobsOfProcessInstance() {
 
     const indexOffset = 1;
 
+    // first, remove all task markers on the BPMN
+    removeAllJobActionMarkers();
+    removeAllConnectorActionMarkers();
+
     jobs.forEach((job, index) => {
       const bpmnElement = job.elementInstance.element;
       let elementFormatted = formatBpmnElementInstance(bpmnElement);
@@ -1070,40 +1074,12 @@ function loadJobsOfProcessInstance() {
         }
       }
     });
-
-    removeTaskPlayableMarkersOfJobs(jobs);
   });
 }
 
 function isConnectorJob(job) {
   // assuming that a job for a connector starts with this prefix
   return job.jobType.startsWith("io.camunda:");
-}
-
-function removeTaskPlayableMarkersOfJobs(jobs) {
-  let elementIdsOfActivatableJobs = jobs
-    .filter(function (job) {
-      return job.state === "ACTIVATABLE";
-    })
-    .map(function (job) {
-      return job.elementInstance.element.elementId;
-    });
-
-  let elementIdsOfNotActivatableJobs = jobs
-    .filter(function (job) {
-      return job.state !== "ACTIVATABLE";
-    })
-    .map(function (job) {
-      return job.elementInstance.element.elementId;
-    });
-
-  elementIdsOfNotActivatableJobs
-    .filter(function (elementId) {
-      return !elementIdsOfActivatableJobs.includes(elementId);
-    })
-    .forEach(function (elementId) {
-      removeTaskPlayableMarker(elementId);
-    });
 }
 
 function loadUserTasksOfProcessInstance() {
@@ -1115,6 +1091,9 @@ function loadUserTasksOfProcessInstance() {
 
     let totalCount = userTasks.totalCount;
     let nodes = userTasks.nodes;
+
+    // first, remove all user task markers on the BPMN
+    removeAllUserTaskActionMarkers();
 
     // TODO (#67): show user tasks in tab
 
@@ -1132,35 +1111,7 @@ function loadUserTasksOfProcessInstance() {
         });
       }
     });
-
-    removeUserTaskMarkers(nodes);
   });
-}
-
-function removeUserTaskMarkers(userTasks) {
-  let elementIdsOfActiveTasks = userTasks
-    .filter(function (userTask) {
-      return userTask.state === "CREATED";
-    })
-    .map(function (userTask) {
-      return userTask.elementInstance.element.elementId;
-    });
-
-  let elementIdsOfNotActiveTasks = userTasks
-    .filter(function (userTask) {
-      return userTask.state !== "CREATED";
-    })
-    .map(function (userTask) {
-      return userTask.elementInstance.element.elementId;
-    });
-
-  elementIdsOfNotActiveTasks
-    .filter(function (elementId) {
-      return !elementIdsOfActiveTasks.includes(elementId);
-    })
-    .forEach(function (elementId) {
-      removeTaskPlayableMarker(elementId);
-    });
 }
 
 function loadIncidentsOfProcessInstance() {

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -124,6 +124,9 @@ function loadProcessInstanceDetailsViews() {
 }
 
 function makeTasksReplayable() {
+  // first, remove all rewind markers
+  overlays.remove({ type: "rewind-marker" });
+
   const tasks = new Set(
     history
       .filter(({ action }) => action === "completeJob")


### PR DESCRIPTION
## Description

Fixing an issue that prevented the invocation of a connector from the BPMN diagram. 

If a job for a connector was active and the data were reloaded, the bottom of the connector didn't invoke the connector anymore. The issue was caused by multiple overlapping overlays for the same element.

Solving the issue by removing all overlays first.

## Related issues
