### PR TITLE
deps: dump EZE from `1.1.0` to `1.2.0-alpha1`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>zeebe-play</artifactId>
@@ -13,16 +15,15 @@
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
     <version>1.4.1</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <maven.version>3.0</maven.version>
-    <zeebe.version>8.1.4</zeebe.version>
     <zeeqs.version>2.7.0</zeeqs.version>
-    <eze.version>1.1.0</eze.version>
+    <eze.version>1.2.0-alpha1</eze.version>
     <hazelcast.version>1.2.1</hazelcast.version>
     <spring-zeebe.version>8.1.17</spring-zeebe.version>
     <camunda-connector-bundle.version>0.16.0</camunda-connector-bundle.version>
@@ -66,6 +67,13 @@
         <groupId>io.zeebe.zeeqs</groupId>
         <artifactId>data</artifactId>
         <version>${zeeqs.version}</version>
+        <exclusions>
+          <!-- use the model API from EZE to avoid version conflicts -->
+          <exclusion>
+            <groupId>io.camunda</groupId>
+            <artifactId>zeebe-bpmn-model</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -452,7 +460,7 @@
         <version>3.2.1</version>
         <configuration>
           <rules>
-            <dependencyConvergence />
+            <dependencyConvergence/>
           </rules>
           <skip>${skip.enforcer-plugin}</skip>
         </configuration>


### PR DESCRIPTION
## Description

Dump `EZ` from `1.1.0` to [1.2.0-alpha4](https://github.com/camunda-community-hub/eze/releases/tag/1.2.0-alpha1).

This allows testing the newest features from Zeebe `8.2.0-alpha4` with Zeebe-Play.

## Related issues
