### PR TITLE
feat: add "Resolve Incident" modal

### DIFF
--- a/src/main/resources/public/css/app.css
+++ b/src/main/resources/public/css/app.css
@@ -11,6 +11,10 @@
   opacity: 0.9;
 }
 
+.hidden {
+  display: none;
+}
+
 .rewind-button {
   padding: 0.2rem 0.35rem;
   padding-right: 0.4rem;
@@ -85,4 +89,13 @@
 /* make form-js powered by appear above bootstrap modal */
 .fjs-powered-by-lightbox {
   z-index: 1100 !important;
+}
+
+#resolve-incident-error-message {
+  background-color: #eee;
+  padding: 1em;
+}
+
+#resolve-incident-variables-section {
+  margin-top: 1em;
 }

--- a/src/main/resources/public/css/app.css
+++ b/src/main/resources/public/css/app.css
@@ -94,6 +94,7 @@
 #resolve-incident-error-message {
   background-color: #eee;
   padding: 1em;
+  white-space: pre-wrap;
 }
 
 #resolve-incident-variables-section {

--- a/src/main/resources/public/js/incident-modal.js
+++ b/src/main/resources/public/js/incident-modal.js
@@ -1,6 +1,8 @@
 async function openResolveIncidentModal(incidentKey, jobKey) {
   const processInstanceKey = getProcessInstanceKey();
 
+  document.querySelector("#new-toast-new-incident .btn-close")?.click();
+
   const [incidentResponse, variableResponse] = await Promise.all([
     queryIncidentsByProcessInstance(processInstanceKey),
     queryVariablesByProcessInstance(processInstanceKey),
@@ -78,6 +80,21 @@ async function confirmResolveIncidentModal() {
       variables,
     });
     refreshHistory();
+  }
+
+  let hasVariables = true;
+  try {
+    hasVariables = Object.keys(JSON.parse(variables || "{}")).length > 0;
+  } catch (e) {
+    // unparseable variable input
+    // let's assume there are variables and let the backend figure it out
+  }
+
+  if (!hasVariables) {
+    return resolveIncident(
+      $("#resolve-incident-key").val(),
+      $("#resolve-incident-jobKey").val()
+    );
   }
 
   sendSetVariablesRequest(getProcessInstanceKey(), scope, variables)

--- a/src/main/resources/public/js/incident-modal.js
+++ b/src/main/resources/public/js/incident-modal.js
@@ -1,0 +1,105 @@
+async function openResolveIncidentModal(incidentKey, jobKey) {
+  const processInstanceKey = getProcessInstanceKey();
+
+  const [incidentResponse, variableResponse] = await Promise.all([
+    queryIncidentsByProcessInstance(processInstanceKey),
+    queryVariablesByProcessInstance(processInstanceKey),
+  ]);
+
+  const variables = variableResponse.data.processInstance.variables;
+  const incident = incidentResponse.data.processInstance.incidents.find(
+    ({ key }) => key === incidentKey
+  );
+
+  document.getElementById("resolve-incident-error-message").textContent =
+    incident.errorMessage;
+
+  document.getElementById("resolve-incident-key").value = incidentKey;
+  document.getElementById("resolve-incident-jobKey").value = jobKey;
+
+  const variablesSection = document.getElementById(
+    "resolve-incident-variables-section"
+  );
+  if (variables.length === 0) {
+    variablesSection.classList.add("hidden");
+  } else {
+    variablesSection.classList.remove("hidden");
+  }
+
+  const variablesTable = document.getElementById(
+    "resolve-incident-variables-table"
+  );
+
+  variablesTable.innerHTML = "";
+
+  variables.forEach((variable) => {
+    const entryHTML = `<td class="name"></td><td class="value"><code></code></td><td class="scope"><span class="badge"></span></td><td class="scopeElement"></td><td class="scopeKey"></td>`;
+    const row = document.createElement("tr");
+
+    row.innerHTML = entryHTML;
+
+    row.querySelector(".name").textContent = variable.name;
+    row.querySelector(".value code").textContent = variable.value;
+
+    if (variable.scope.element.bpmnElementType === "PROCESS") {
+      row.querySelector(".badge").textContent = "global";
+      row.querySelector(".badge").classList.add("bg-primary");
+    } else {
+      row.querySelector(".badge").textContent = "local";
+      row.querySelector(".badge").classList.add("bg-secondary");
+    }
+
+    row.querySelector(".scopeElement").innerHTML = formatBpmnElementInstance(
+      variable.scope.element
+    );
+    row
+      .querySelector(".scopeElement")
+      .removeChild(row.querySelector(".scopeElement button"));
+
+    row.querySelector(".scopeKey").textContent = variable.scope.key;
+
+    variablesTable.appendChild(row);
+  });
+
+  $("#resolve-incident-modal").modal("show");
+}
+
+async function confirmResolveIncidentModal() {
+  $("#resolve-incident-modal").modal("hide");
+
+  let scope = $("#resolve-incident-variables-scope").val();
+  const variables = $("#resolve-incident-variables-payload").val();
+
+  if (scope === "global") {
+    scope = getProcessInstanceKey();
+
+    history.push({
+      action: "setVariables",
+      variables,
+    });
+    refreshHistory();
+  }
+
+  sendSetVariablesRequest(getProcessInstanceKey(), scope, variables)
+    .done((key) => {
+      const incidentKey = $("#resolve-incident-key").val();
+      const jobKey = $("#resolve-incident-jobKey").val();
+
+      document.getElementById("resolve-incident-variables-scope").value =
+        "global";
+      document.getElementById("resolve-incident-variables-payload").value = "";
+
+      showNotificationSuccess(
+        "set-variables-" + key,
+        "Set variables <code>" + variables + "</code>."
+      );
+
+      resolveIncident(incidentKey, jobKey);
+    })
+    .fail(
+      showFailure(
+        "set-variables" + scope,
+        "Failed to set variables <code>" + variables + "</code>."
+      )
+    );
+}

--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -713,7 +713,7 @@ function throwErrorJobModal() {
 }
 
 function resetJobModal() {
-  $("#jobVariables").val("{}");
+  $("#jobVariables").val("");
   $("#jobRetries").val("0");
   $("#jobErrorMessage").val("");
   $("#jobErrorCode").val("");

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -1665,6 +1665,8 @@ function loadElementInfoOfProcessInstance() {
 function switchToIncidentsTab(evt) {
   evt.preventDefault();
 
+  evt.target.closest(".toast").querySelector(".btn-close").click();
+
   if (detailsCollapsed) {
     toggleDetailsCollapse();
   }

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -1060,7 +1060,7 @@ function loadJobsOfProcessInstance() {
             );
             let jobVariables = cachedResponse;
             if (!cachedResponse) {
-              jobVariables = "{}";
+              jobVariables = "";
             }
             showJobCompleteModal(job.key, "complete", jobVariables);
           });
@@ -1180,7 +1180,7 @@ function loadUserTasksOfProcessInstance() {
         );
         let jobVariables = cachedResponse;
         if (!cachedResponse) {
-          jobVariables = "{}";
+          jobVariables = "";
         }
         showJobCompleteModal(userTask.key, "complete", jobVariables);
       });
@@ -1192,6 +1192,7 @@ function loadUserTasksOfProcessInstance() {
   });
 }
 
+let previousNumberOfIncidents;
 function loadIncidentsOfProcessInstance() {
   const processInstanceKey = getProcessInstanceKey();
 
@@ -1204,6 +1205,18 @@ function loadIncidentsOfProcessInstance() {
     $("#incidents-total-count").text(totalCount);
 
     $("#incidents-of-process-instance-table tbody").empty();
+
+    if (
+      typeof previousNumberOfIncidents === "number" &&
+      previousNumberOfIncidents < totalCount
+    ) {
+      // a new incident occured, let's inform the user about it
+      showNotificationFailure(
+        "new-incident",
+        `<a href="#" onclick="switchToIncidentsTab(event)">A new incident occured!</a>`
+      );
+    }
+    previousNumberOfIncidents = totalCount;
 
     const indexOffset = 1;
 
@@ -1222,7 +1235,8 @@ function loadIncidentsOfProcessInstance() {
         jobKey = incident.job.key;
       }
 
-      const action = "resolveIncident(" + incident.key + ", " + jobKey + ");";
+      const action =
+        "openResolveIncidentModal('" + incident.key + "', '" + jobKey + "');";
 
       let actionButton = "";
       if (isActiveIncident) {
@@ -1646,4 +1660,14 @@ function loadElementInfoOfProcessInstance() {
     const elements = process.elements;
     elements.forEach((element) => showInfoOfBpmnElement(element));
   });
+}
+
+function switchToIncidentsTab(evt) {
+  evt.preventDefault();
+
+  if (detailsCollapsed) {
+    toggleDetailsCollapse();
+  }
+
+  document.getElementById("incidents-tab").click();
 }

--- a/src/main/resources/public/js/view-process.js
+++ b/src/main/resources/public/js/view-process.js
@@ -144,7 +144,7 @@ function createNewProcessInstance() {
 
 function createNewProcessInstanceWithVariables() {
   const processKey = getProcessKey();
-  const variables = $("#newInstanceVariables").val();
+  const variables = $("#newInstanceVariables").val() || "{}";
 
   let json = JSON.parse(variables);
 

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -34,4 +34,6 @@
   <script src="/js/view-monitoring.js" type="text/javascript"></script>
   <script src="/js/view-process-instance.js" type="text/javascript"></script>
   <script src="/js/view-connectors.js" type="text/javascript"></script>
+
+  <script src="/js/incident-modal.js" type="text/javascript"></script>
 </div>

--- a/src/main/resources/templates/views/modals/complete-job-modal.html
+++ b/src/main/resources/templates/views/modals/complete-job-modal.html
@@ -33,9 +33,12 @@
               <label for="jobVariables" class="form-label"
                 >Variables (JSON)</label
               >
-              <textarea class="form-control" id="jobVariables" rows="3">
-{}</textarea
-              >
+              <textarea
+                class="form-control"
+                id="jobVariables"
+                rows="3"
+                placeholder='{"variableName": "variableValue"}'
+              ></textarea>
             </div>
           </form>
         </div>

--- a/src/main/resources/templates/views/modals/resolve-incident-modal.html
+++ b/src/main/resources/templates/views/modals/resolve-incident-modal.html
@@ -1,0 +1,95 @@
+<div th:fragment="resolve-incident-modal">
+  <div
+    class="modal fade"
+    id="resolve-incident-modal"
+    tabindex="-1"
+    aria-hidden="true"
+  >
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="taskFormModal">Resolve Incident</h5>
+          <button
+            type="button"
+            class="btn-close"
+            data-bs-dismiss="modal"
+            aria-label="Close"
+          ></button>
+        </div>
+        <div class="modal-body">
+          <p>Error Message:</p>
+          <pre id="resolve-incident-error-message"></pre>
+          <p>
+            <b>
+              You may want to set variables in order to resolve this incident:
+            </b>
+          </p>
+          <form class="form">
+            <input type="hidden" id="resolve-incident-key" />
+            <input type="hidden" id="resolve-incident-jobKey" />
+            <div class="row">
+              <div class="col col-md-3">
+                <label for="resolve-incident-variables-scope" class="form-label"
+                  >Scope</label
+                >
+                <input
+                  class="form-control"
+                  id="resolve-incident-variables-scope"
+                  type="text"
+                  value="global"
+                />
+              </div>
+              <div class="col">
+                <label
+                  for="resolve-incident-variables-payload"
+                  class="form-label"
+                  >Variables (JSON)</label
+                >
+                <textarea
+                  class="form-control"
+                  id="resolve-incident-variables-payload"
+                  rows="1"
+                  placeholder='{"variableName": "variableValue"}'
+                ></textarea>
+              </div>
+            </div>
+          </form>
+
+          <details id="resolve-incident-variables-section">
+            <summary>Existing Variables</summary>
+            <table class="table table-striped table-hover caption-top">
+              <thead>
+                <tr>
+                  <th scope="col">Name</th>
+                  <th scope="col">Value</th>
+                  <th scope="col">Scope</th>
+                  <th scope="col">Scope Element</th>
+                  <th scope="col">Scope Key</th>
+                </tr>
+              </thead>
+              <tbody id="resolve-incident-variables-table"></tbody>
+            </table>
+          </details>
+        </div>
+        <div class="modal-footer">
+          <div>
+            <button
+              type="button"
+              class="btn btn-secondary"
+              data-bs-dismiss="modal"
+            >
+              Close
+            </button>
+            <button
+              type="button"
+              class="btn btn-primary"
+              onclick="confirmResolveIncidentModal();"
+            >
+              Resolve Incident
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/main/resources/templates/views/monitoring/process-instances/process-instance.html
+++ b/src/main/resources/templates/views/monitoring/process-instances/process-instance.html
@@ -27,6 +27,9 @@
     <div
       th:replace="views/modals/task-form-modal.html :: #task-form-modal"
     ></div>
+    <div
+      th:replace="views/modals/resolve-incident-modal.html :: #resolve-incident-modal"
+    ></div>
 
     <div class="container-fluid">
       <div class="row justify-content-between">

--- a/src/main/resources/templates/views/new-instance-modal.html
+++ b/src/main/resources/templates/views/new-instance-modal.html
@@ -23,9 +23,12 @@
               <label for="newInstanceVariables" class="form-label"
                 >Variables (JSON)</label
               >
-              <textarea class="form-control" id="newInstanceVariables" rows="3">
-{}</textarea
-              >
+              <textarea
+                class="form-control"
+                id="newInstanceVariables"
+                rows="3"
+                placeholder='{"variableName": "variableValue"}'
+              ></textarea>
             </div>
           </form>
         </div>

--- a/src/main/resources/templates/views/publish-message-modal.html
+++ b/src/main/resources/templates/views/publish-message-modal.html
@@ -49,9 +49,8 @@
                 class="form-control"
                 id="publishMessageVariables"
                 rows="3"
-              >
-{}</textarea
-              >
+                placeholder='{"variableName": "variableValue"}'
+              ></textarea>
             </div>
             <div class="mb-3">
               <label for="publishMessageTimeToLive" class="form-label"

--- a/src/main/resources/templates/views/set-variables-modal.html
+++ b/src/main/resources/templates/views/set-variables-modal.html
@@ -32,9 +32,12 @@
               <label for="updatedVariables" class="form-label"
                 >Variables (JSON)</label
               >
-              <textarea class="form-control" id="updatedVariables" rows="3">
-{}</textarea
-              >
+              <textarea
+                class="form-control"
+                id="updatedVariables"
+                rows="3"
+                placeholder='{"variableName": "variableValue"}'
+              ></textarea>
             </div>
           </form>
         </div>


### PR DESCRIPTION
## Description

This PR adds a modal that is opened when the user wants to resolve an incident. This modal contains the incident error message as well as a way to set variables before resolving the incident.

This PR also adds a notification when a new incident occurs with a clickable element that opens the incident tab.

This PR also removes the prefilled empty object in places where variables are specified and replaces it with a placeholder showing sample JSON to specify a single variable with a string value.

## Related issues

closes #134 