### PR TITLE
fix: DMN execution and record exporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <maven.version>3.0</maven.version>
     <zeeqs.version>2.7.0</zeeqs.version>
     <eze.version>1.2.0-alpha1</eze.version>
-    <hazelcast.version>1.3.1</hazelcast.version>
+    <hazelcast.version>1.4.0-alpha1</hazelcast.version>
     <spring-zeebe.version>8.1.17</spring-zeebe.version>
     <camunda-connector-bundle.version>0.16.1</camunda-connector-bundle.version>
     <camunda-connector-sdk.version>0.6.0</camunda-connector-sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <maven.version>3.0</maven.version>
     <zeeqs.version>2.7.0</zeeqs.version>
     <eze.version>1.2.0-alpha1</eze.version>
-    <hazelcast.version>1.2.1</hazelcast.version>
+    <hazelcast.version>1.3.1</hazelcast.version>
     <spring-zeebe.version>8.1.17</spring-zeebe.version>
     <camunda-connector-bundle.version>0.16.1</camunda-connector-bundle.version>
     <camunda-connector-sdk.version>0.6.0</camunda-connector-sdk.version>


### PR DESCRIPTION
## Description

Fix the DMN execution by aligning the dependency versions to Zeebe `8.2.0-alpha4`

- dump `zeebe-hazelcast-exporter` from `1.2.1` to `1.4.0-alpha1`

## Related issues
