### PR TITLE
fix: re-establish GraphQL subscription after websocket close

### DIFF
--- a/src/main/resources/public/js/zeeqs-client.js
+++ b/src/main/resources/public/js/zeeqs-client.js
@@ -780,6 +780,15 @@ function openSubscription(subscription, handler) {
       handler(response);
     }
   });
+
+  socket.addEventListener("error", (error) => {
+    console.error("GraphQL subscription error", error);
+  });
+
+  socket.addEventListener("close", () => {
+    // the connection was closed. This can happen due to inactivity, let's re-establish the connection
+    openSubscription(subscription, handler);
+  });
 }
 
 function subscribeToProcessInstanceUpdates(type, key, handler) {


### PR DESCRIPTION
## Description

This PR adds a close event handler to the GraphQL websocket connection that, when called, re-establishes the connection. My hope is that this solves #143.

I could not verify this yet as the websocket on my dev-setup does not timeout in the same way it does in production so I would keep the issue open until I was able to verify the fix on production.

## Related issues

related to #143