### PR TITLE
feat: Complete connector job

### DIFF
--- a/src/main/resources/public/js/view-bpmn.js
+++ b/src/main/resources/public/js/view-bpmn.js
@@ -354,31 +354,64 @@ function makeTaskPlayable(elementId, jobKey, { isUserTask, taskForm } = {}) {
 }
 
 function makeConnectorTaskPlayable(elementId, jobKey, jobType) {
-  let buttonId = `connector-execute-${jobKey}`;
+  let connectorButtonId = `connector-execute-${jobKey}`;
+  let completeButtonId = `connector-complete-${jobKey}`;
 
   let content = `
-      <button id="${buttonId}" type="button" class="btn btn-sm btn-primary" title="Invoke connector">
-        <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#plugin"/></svg>
-      </button>`;
+    <div class="btn-group">
+      <button id="${connectorButtonId}" type="button"
+              class="btn btn-sm btn-primary overlay-button" title="Invoke connector">
+        <svg class="bi" width="18" height="18" fill="white">
+          <use xlink:href="/img/bootstrap-icons.svg#plugin"/>
+        </svg>
+      </button>
+      <button type="button"
+              class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split"
+              data-bs-toggle="dropdown" aria-expanded="false"><span
+          class="visually-hidden">Toggle Dropdown</span></button>
+      <ul class="dropdown-menu">
+        <li>
+          <a id="${completeButtonId}" class="dropdown-item" href="#">
+            <svg class="bi" width="18" height="18" fill="black">
+              <use xlink:href="/img/bootstrap-icons.svg#check"/>
+            </svg>
+            Complete
+          </a>
+        </li>
+      </ul>
+    </div>`;
 
   overlays.add(elementId, "connector-action", {
     position: {
       top: -20,
-      left: -20,
+      left: -40,
     },
     html: content,
   });
 
-  const buttonElement = $("#" + buttonId);
-  buttonElement.click(function () {
+  const connectorButtonElement = $("#" + connectorButtonId);
+  connectorButtonElement.click(function () {
     executeConnectorJob(jobType, jobKey);
   });
 
-  buttonElement.tooltip();
+  connectorButtonElement.tooltip();
 
   // We have to remove the tooltip manually when removing the element that triggers it
   // see https://github.com/twbs/bootstrap/issues/3084#issuecomment-5207780
-  buttonElement.on("click", () => {
+  connectorButtonElement.on("click", () => {
+    $(`[data-bs-toggle="tooltip"]`).tooltip("hide");
+  });
+
+  $("#" + completeButtonId).click(function () {
+    const cachedResponse = localStorage.getItem(
+      "jobCompletion " + getBpmnProcessId() + " " + elementId
+    );
+    let jobVariables = cachedResponse;
+    if (!cachedResponse) {
+      jobVariables = "";
+    }
+    showJobCompleteModal(jobKey, "complete", jobVariables);
+
     $(`[data-bs-toggle="tooltip"]`).tooltip("hide");
   });
 }

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -1010,12 +1010,23 @@ function loadJobsOfProcessInstance() {
 
       if (isActiveJob) {
         if (isConnectorJob(job)) {
-          // a job for a connector can only be invoked
+          // a job for a connector can be invoked, or completed with variables
           actionButton = `
-            <button id="${connectorButtonId}" type="button" class="btn btn-sm btn-primary">
-              <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#plugin"/></svg>
-              Invoke
-            </button>`;
+            <div class="btn-group">
+              <button id="${connectorButtonId}" type="button" class="btn btn-sm btn-primary overlay-button">
+                <svg class="bi" width="18" height="18" fill="white"><use xlink:href="/img/bootstrap-icons.svg#plugin"/></svg>
+                Invoke
+              </button>
+              <button type="button" class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false"><span class="visually-hidden">Toggle Dropdown</span></button>
+                <ul class="dropdown-menu">
+                  <li>
+                    <a id="${jobCompleteButtonId}" class="dropdown-item" href="#">
+                      <svg class="bi" width="18" height="18" fill="black"><use xlink:href="/img/bootstrap-icons.svg#check"/></svg>
+                    Complete
+                  </a>
+                </li>
+              </ul>
+            </div>`;
         } else {
           // show all actions for a regular job
           actionButton = `
@@ -1055,26 +1066,25 @@ function loadJobsOfProcessInstance() {
           </tr>`);
 
       if (isActiveJob) {
+        // bind actions for job/connector buttons
+        $("#" + jobCompleteButtonId).click(function () {
+          const cachedResponse = localStorage.getItem(
+            "jobCompletion " + getBpmnProcessId() + " " + elementId
+          );
+          let jobVariables = cachedResponse;
+          if (!cachedResponse) {
+            jobVariables = "";
+          }
+          showJobCompleteModal(job.key, "complete", jobVariables);
+        });
+
         if (isConnectorJob(job)) {
-          // bind action for connector button
           $("#" + connectorButtonId).click(function () {
             executeConnectorJob(job.jobType, job.key);
           });
 
           makeConnectorTaskPlayable(elementId, job.key, job.jobType);
         } else {
-          // bind actions for job buttons
-          $("#" + jobCompleteButtonId).click(function () {
-            const cachedResponse = localStorage.getItem(
-              "jobCompletion " + getBpmnProcessId() + " " + elementId
-            );
-            let jobVariables = cachedResponse;
-            if (!cachedResponse) {
-              jobVariables = "";
-            }
-            showJobCompleteModal(job.key, "complete", jobVariables);
-          });
-
           $("#" + jobFailButtonId).click(function () {
             fillJobModal(job.key, "fail");
           });
@@ -1203,6 +1213,7 @@ function loadUserTasksOfProcessInstance() {
 }
 
 let previousNumberOfIncidents;
+
 function loadIncidentsOfProcessInstance() {
   const processInstanceKey = getProcessInstanceKey();
 


### PR DESCRIPTION
## Description

Add a new option to complete a connector job without invoking the connector. Instead, the job is completed with the provided variables.

## Related issues

Related to https://github.com/camunda/product-hub/issues/969