### PR TITLE
Dump connectors from 0.16.1 to 0.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
     <eze.version>1.2.0-alpha2</eze.version>
     <hazelcast.version>1.4.0-alpha1</hazelcast.version>
     <spring-zeebe.version>8.1.17</spring-zeebe.version>
-    <camunda-connector-bundle.version>0.16.1</camunda-connector-bundle.version>
-    <camunda-connector-sdk.version>0.6.0</camunda-connector-sdk.version>
+    <camunda-connector-bundle.version>0.17.0</camunda-connector-bundle.version>
+    <camunda-connector-sdk.version>0.7.0</camunda-connector-sdk.version>
 
     <kotlin.version>1.8.10</kotlin.version>
     <spring.boot.version>2.7.8</spring.boot.version>

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorService.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorService.kt
@@ -1,7 +1,7 @@
 package org.camunda.community.zeebe.play.connectors
 
 import io.camunda.connector.impl.outbound.OutboundConnectorConfiguration
-import io.camunda.connector.runtime.util.outbound.OutboundConnectorRegistrationHelper
+import io.camunda.connector.runtime.util.discovery.SPIConnectorDiscovery
 import io.camunda.zeebe.model.bpmn.Bpmn
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput
@@ -55,9 +55,7 @@ class ConnectorService(
     }
 
     fun findAvailableConnectors(): List<OutboundConnectorConfiguration> {
-        return OutboundConnectorRegistrationHelper
-            .parseFromSPI()
-            .toList()
+        return SPIConnectorDiscovery.discoverOutbound().toList()
     }
 
 }

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
@@ -1,6 +1,7 @@
 package org.camunda.community.zeebe.play.connectors
 
 import io.camunda.connector.api.secret.SecretProvider
+import io.camunda.connector.runtime.util.ConnectorHelper
 import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler
 import io.camunda.zeebe.client.ZeebeClient
 import io.camunda.zeebe.spring.client.lifecycle.ZeebeClientLifecycle
@@ -39,10 +40,14 @@ class ConnectorsConfig(
             connectorService
                 .findAvailableConnectors()
                 .forEach { connectorConfig ->
+                    val connector =
+                        ConnectorHelper.instantiateConnector(connectorConfig.connectorClass)
+                    val jobHandler = ConnectorJobHandler(connector, secretProvider)
+
                     zeebeClient
                         .newWorker()
                         .jobType(connectorConfig.type)
-                        .handler(ConnectorJobHandler(connectorConfig.function, secretProvider))
+                        .handler(jobHandler)
                         .name(connectorConfig.name)
                         .fetchVariables(connectorConfig.inputVariables.toList())
                         .open()

--- a/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorsResource.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorsResource.kt
@@ -1,6 +1,7 @@
 package org.camunda.community.zeebe.play.rest
 
 import io.camunda.connector.impl.outbound.OutboundConnectorConfiguration
+import io.camunda.connector.runtime.util.ConnectorHelper
 import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler
 import io.camunda.zeebe.client.ZeebeClient
 import io.camunda.zeebe.client.api.response.ActivatedJob
@@ -35,7 +36,8 @@ class ConnectorsResource(
             .find { it.type == jobType }
             ?: throw RuntimeException("No connector found with job type '$jobType'."))
 
-        val jobHandler = ConnectorJobHandler(connectorConfig.function, connectorsSecretProvider)
+        val connector = ConnectorHelper.instantiateConnector(connectorConfig.connectorClass)
+        val jobHandler = ConnectorJobHandler(connector, connectorsSecretProvider)
 
         findConnectorJob(connectorConfig, jobKey)
             ?.let { jobHandler.handle(zeebeClient, it) }


### PR DESCRIPTION
## Description

- dump connectors-bundle from 0.16.1 to 0.17.0 
- dump connector-sdk from 0.6.0 to 0.7.0
- adopt new connectors API

## Related issues
