### PR TITLE
feat: Call it just "Play" in Camunda hosted instances

### DIFF
--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -23,5 +23,14 @@
 
   <link rel="icon" href="/img/favicon.ico" />
 
-  <title>Zeebe Play</title>
+  <title
+    th:unless="${#httpServletRequest.requestURL.toString().contains('play.camunda.io')}"
+  >
+    Zeebe Play
+  </title>
+  <title
+    th:if="${#httpServletRequest.requestURL.toString().contains('play.camunda.io')}"
+  >
+    Play
+  </title>
 </head>

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -3,7 +3,11 @@
   th:fragment="navbar"
 >
   <div class="container-fluid">
-    <a class="navbar-brand" href="/view/home">
+    <a
+      th:unless="${#httpServletRequest.requestURL.toString().contains('play.camunda.io')}"
+      class="navbar-brand"
+      href="/view/home"
+    >
       <img
         src="/img/logo.png"
         alt=""
@@ -15,6 +19,13 @@
       <svg class="bi" width="24" height="24" fill="cornflowerblue">
         <use xlink:href="/img/bootstrap-icons.svg#play" />
       </svg>
+    </a>
+    <a
+      th:if="${#httpServletRequest.requestURL.toString().contains('play.camunda.io')}"
+      class="navbar-brand"
+      href="/view/home"
+    >
+      Play
     </a>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -10,7 +10,16 @@
 
     <link rel="icon" href="/img/favicon.ico" />
 
-    <title>Zeebe Play</title>
+    <title
+      th:unless="${#httpServletRequest.requestURL.toString().contains('play.camunda.io')}"
+    >
+      Zeebe Play
+    </title>
+    <title
+      th:if="${#httpServletRequest.requestURL.toString().contains('play.camunda.io')}"
+    >
+      Play
+    </title>
   </head>
 
   <body>
@@ -19,7 +28,11 @@
       th:fragment="navbar"
     >
       <div class="container-fluid">
-        <a class="navbar-brand" href="#">
+        <a
+          th:unless="${#httpServletRequest.requestURL.toString().contains('play.camunda.io')}"
+          class="navbar-brand"
+          href="#"
+        >
           <img
             src="/img/logo.png"
             alt=""
@@ -28,6 +41,13 @@
             class="d-inline-block align-text-top"
           />
           Zeebe Play
+        </a>
+        <a
+          th:if="${#httpServletRequest.requestURL.toString().contains('play.camunda.io')}"
+          class="navbar-brand"
+          href="#"
+        >
+          Play
         </a>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">

--- a/src/main/resources/templates/views/home.html
+++ b/src/main/resources/templates/views/home.html
@@ -1,253 +1,259 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/header :: head"></head>
-<body onload="loadHomeView();">
-<div th:replace="fragments/navbar :: navbar"></div>
+  <head th:replace="fragments/header :: head"></head>
+  <body onload="loadHomeView();">
+    <div th:replace="fragments/navbar :: navbar"></div>
 
-<div class="container-fluid w-75">
-  <div class="row row-cols-1 row-cols-md-3 g-4">
-    <div class="col">
-      <div class="card h-100">
-        <h5 class="card-header">
-          <svg class="bi" width="24" height="24">
-            <use xlink:href="/img/bootstrap-icons.svg#upload"/>
-          </svg>
-          Get started
-        </h5>
-        <div class="card-body">
-          <p class="card-text">
-            Go to <a href="/view/deployment">deployments</a> and click on
-            <button type="button" class="btn btn-sm btn-primary">
-              <svg class="bi" width="18" height="18" fill="white">
-                <use xlink:href="/img/bootstrap-icons.svg#upload"/>
+    <div class="container-fluid w-75">
+      <div class="row row-cols-1 row-cols-md-3 g-4">
+        <div class="col">
+          <div class="card h-100">
+            <h5 class="card-header">
+              <svg class="bi" width="24" height="24">
+                <use xlink:href="/img/bootstrap-icons.svg#upload" />
               </svg>
-            </button>
-            to deploy a new process and other resources. Or, use the Camunda
-            modeler or a Zeebe client.
-          </p>
-          <p class="card-text">
-            Select the deployed process, look for the start event
-            <span class="bpmn-icon-start-event-none fs-3"></span> and click
-            on
-            <button type="button" class="btn btn-sm btn-primary">
-              <svg class="bi" width="18" height="18" fill="white">
-                <use xlink:href="/img/bootstrap-icons.svg#play"/>
+              Get started
+            </h5>
+            <div class="card-body">
+              <p class="card-text">
+                Go to <a href="/view/deployment">deployments</a> and click on
+                <button type="button" class="btn btn-sm btn-primary">
+                  <svg class="bi" width="18" height="18" fill="white">
+                    <use xlink:href="/img/bootstrap-icons.svg#upload" />
+                  </svg>
+                </button>
+                to deploy a new process and other resources. Or, use the Camunda
+                modeler or a Zeebe client.
+              </p>
+              <p class="card-text">
+                Select the deployed process, look for the start event
+                <span class="bpmn-icon-start-event-none fs-3"></span> and click
+                on
+                <button type="button" class="btn btn-sm btn-primary">
+                  <svg class="bi" width="18" height="18" fill="white">
+                    <use xlink:href="/img/bootstrap-icons.svg#play" />
+                  </svg>
+                </button>
+                to create a new process instance.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card h-100">
+            <h5 class="card-header">
+              <svg class="bi" width="32" height="32">
+                <use xlink:href="/img/bootstrap-icons.svg#play" />
               </svg>
-            </button>
-            to create a new process instance.
-          </p>
+              Drive the process instance
+            </h5>
+            <div class="card-body">
+              <p class="card-text">
+                Select a task
+                <span class="bpmn-icon-service-task fs-3"></span> and click on
+                <button type="button" class="btn btn-sm btn-primary">
+                  <svg class="bi" width="18" height="18" fill="white">
+                    <use xlink:href="/img/bootstrap-icons.svg#play" />
+                  </svg>
+                </button>
+                to complete it.
+              </p>
+              <p class="card-text">
+                Or, select a start event
+                <span class="bpmn-icon-start-event-message fs-3"></span> or a
+                catch event
+                <span
+                  class="bpmn-icon-intermediate-event-catch-timer fs-3"
+                ></span>
+                and publish a message
+                <button type="button" class="btn btn-sm btn-primary">
+                  <svg class="bi" width="18" height="18" fill="white">
+                    <use xlink:href="/img/bootstrap-icons.svg#envelope" />
+                  </svg>
+                </button>
+                or manipulate the time
+                <button type="button" class="btn btn-sm btn-primary">
+                  <svg class="bi" width="18" height="18" fill="white">
+                    <use xlink:href="/img/bootstrap-icons.svg#clock" />
+                  </svg>
+                </button>
+                to trigger the event.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card h-100">
+            <h5 class="card-header">
+              <svg class="bi" width="32" height="32">
+                <use xlink:href="/img/bootstrap-icons.svg#easel" />
+              </svg>
+              Demo process
+            </h5>
+            <div class="card-body">
+              <p class="card-text">
+                Try out
+                <span
+                  th:unless="${#httpServletRequest.requestURL.toString().contains('play.camunda.io')}"
+                  >Zeebe Play</span
+                >
+                <span
+                  th:if="${#httpServletRequest.requestURL.toString().contains('play.camunda.io')}"
+                  >Play</span
+                >
+                by using a demo process. Click on the buttons below.
+              </p>
+            </div>
+            <ul class="list-group list-group-flush">
+              <li class="list-group-item">
+                <button class="btn btn-sm btn-primary" onclick="deployDemo();">
+                  <svg class="bi" width="18" height="18" fill="white">
+                    <use xlink:href="/img/bootstrap-icons.svg#upload" />
+                  </svg>
+                </button>
+                First, deploy the demo process
+              </li>
+              <li class="list-group-item">
+                <button
+                  id="demo-create-instance-button"
+                  class="btn btn-sm btn-primary"
+                  disabled
+                >
+                  <svg class="bi" width="18" height="18" fill="white">
+                    <use xlink:href="/img/bootstrap-icons.svg#play" />
+                  </svg>
+                </button>
+                Then, create a new process instance
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card h-100">
+            <h5 class="card-header">
+              <svg class="bi" width="32" height="32">
+                <use xlink:href="/img/bootstrap-icons.svg#person" />
+              </svg>
+              User forms
+            </h5>
+            <div class="card-body">
+              <p class="card-text">
+                Select a user task
+                <span class="bpmn-icon-user-task fs-3"></span> with a
+                <a
+                  href="https://docs.camunda.io/docs/guides/utilizing-forms/"
+                  target="_blank"
+                  >Camunda form</a
+                >
+                and click on
+                <button type="button" class="btn btn-sm btn-primary">
+                  <img
+                    width="18"
+                    height="18"
+                    style="margin-top: -4px"
+                    src="/img/edit-form.svg"
+                  />
+                </button>
+                to see the form and fill it out. The user task gets completed
+                with the form data.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card h-100">
+            <h5 class="card-header">
+              <svg class="bi" width="32" height="32">
+                <use xlink:href="/img/bootstrap-icons.svg#plugin" />
+              </svg>
+              Connectors
+            </h5>
+            <div class="card-body">
+              <p class="card-text">
+                Select a task
+                <span class="bpmn-icon-service-task fs-3"></span> of an
+                available
+                <a
+                  href="https://docs.camunda.io/docs/components/connectors/use-connectors/"
+                  target="_blank"
+                  >connector</a
+                >
+                and click on
+                <button type="button" class="btn btn-sm btn-primary">
+                  <svg class="bi" width="18" height="18" fill="white">
+                    <use xlink:href="/img/bootstrap-icons.svg#plugin" />
+                  </svg>
+                </button>
+                to invoke the connector and complete the task.
+              </p>
+              <p class="card-text">
+                Go to <a href="/view/connectors">connectors</a> and see the
+                available connectors.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card h-100">
+            <h5 class="card-header">
+              <svg class="bi" width="32" height="32">
+                <use xlink:href="/img/bootstrap-icons.svg#rewind" />
+              </svg>
+              Rewind
+            </h5>
+            <div class="card-body">
+              <p class="card-text">
+                Select a completed task
+                <span class="bpmn-icon-service-task fs-3"></span>
+                and click on
+                <button type="button" class="btn btn-sm btn-primary">
+                  <svg class="bi" width="18" height="18" fill="white">
+                    <use xlink:href="/img/bootstrap-icons.svg#rewind" />
+                  </svg>
+                </button>
+                to rewind the process to this task. From here, you can try out
+                different paths or inputs.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col">
+          <div class="card h-100">
+            <h5 class="card-header">
+              <svg class="bi" width="32" height="32" fill="black">
+                <use xlink:href="/img/bootstrap-icons.svg#info-circle" />
+              </svg>
+              Status info
+            </h5>
+            <div class="card-body">
+              <table class="table">
+                <tbody>
+                  <tr>
+                    <td>Zeebe-Play version</td>
+                    <td id="version-zeebe-play">?</td>
+                  </tr>
+                  <tr>
+                    <td>Zeebe engine version</td>
+                    <td id="version-zeebe-engine">?</td>
+                  </tr>
+                  <tr>
+                    <td>Status</td>
+                    <td id="status">?</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
       </div>
     </div>
 
-    <div class="col">
-      <div class="card h-100">
-        <h5 class="card-header">
-          <svg class="bi" width="32" height="32">
-            <use xlink:href="/img/bootstrap-icons.svg#play"/>
-          </svg>
-          Drive the process instance
-        </h5>
-        <div class="card-body">
-          <p class="card-text">
-            Select a task
-            <span class="bpmn-icon-service-task fs-3"></span> and click on
-            <button type="button" class="btn btn-sm btn-primary">
-              <svg class="bi" width="18" height="18" fill="white">
-                <use xlink:href="/img/bootstrap-icons.svg#play"/>
-              </svg>
-            </button>
-            to complete it.
-          </p>
-          <p class="card-text">
-            Or, select a start event
-            <span class="bpmn-icon-start-event-message fs-3"></span> or a
-            catch event
-            <span
-                class="bpmn-icon-intermediate-event-catch-timer fs-3"
-            ></span>
-            and publish a message
-            <button type="button" class="btn btn-sm btn-primary">
-              <svg class="bi" width="18" height="18" fill="white">
-                <use xlink:href="/img/bootstrap-icons.svg#envelope"/>
-              </svg>
-            </button>
-            or manipulate the time
-            <button type="button" class="btn btn-sm btn-primary">
-              <svg class="bi" width="18" height="18" fill="white">
-                <use xlink:href="/img/bootstrap-icons.svg#clock"/>
-              </svg>
-            </button>
-            to trigger the event.
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col">
-      <div class="card h-100">
-        <h5 class="card-header">
-          <svg class="bi" width="32" height="32">
-            <use xlink:href="/img/bootstrap-icons.svg#easel"/>
-          </svg>
-          Demo process
-        </h5>
-        <div class="card-body">
-          <p class="card-text">
-            Try out Zeebe Play by using a demo process. Click on the buttons
-            below.
-          </p>
-        </div>
-        <ul class="list-group list-group-flush">
-          <li class="list-group-item">
-            <button class="btn btn-sm btn-primary" onclick="deployDemo();">
-              <svg class="bi" width="18" height="18" fill="white">
-                <use xlink:href="/img/bootstrap-icons.svg#upload"/>
-              </svg>
-            </button>
-            First, deploy the demo process
-          </li>
-          <li class="list-group-item">
-            <button
-                id="demo-create-instance-button"
-                class="btn btn-sm btn-primary"
-                disabled
-            >
-              <svg class="bi" width="18" height="18" fill="white">
-                <use xlink:href="/img/bootstrap-icons.svg#play"/>
-              </svg>
-            </button>
-            Then, create a new process instance
-          </li>
-        </ul>
-      </div>
-    </div>
-
-    <div class="col">
-      <div class="card h-100">
-        <h5 class="card-header">
-          <svg class="bi" width="32" height="32">
-            <use xlink:href="/img/bootstrap-icons.svg#person"/>
-          </svg>
-          User forms
-        </h5>
-        <div class="card-body">
-          <p class="card-text">
-            Select a user task
-            <span class="bpmn-icon-user-task fs-3"></span> with a
-            <a
-                href="https://docs.camunda.io/docs/guides/utilizing-forms/"
-                target="_blank"
-            >Camunda form</a
-            >
-            and click on
-            <button type="button" class="btn btn-sm btn-primary">
-              <img
-                  width="18"
-                  height="18"
-                  style="margin-top: -4px"
-                  src="/img/edit-form.svg"
-              />
-            </button>
-            to see the form and fill it out. The user task gets completed
-            with the form data.
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col">
-      <div class="card h-100">
-        <h5 class="card-header">
-          <svg class="bi" width="32" height="32">
-            <use xlink:href="/img/bootstrap-icons.svg#plugin"/>
-          </svg>
-          Connectors
-        </h5>
-        <div class="card-body">
-          <p class="card-text">
-            Select a task
-            <span class="bpmn-icon-service-task fs-3"></span> of an
-            available
-            <a
-                href="https://docs.camunda.io/docs/components/connectors/use-connectors/"
-                target="_blank"
-            >connector</a
-            >
-            and click on
-            <button type="button" class="btn btn-sm btn-primary">
-              <svg class="bi" width="18" height="18" fill="white">
-                <use xlink:href="/img/bootstrap-icons.svg#plugin"/>
-              </svg>
-            </button>
-            to invoke the connector and complete the task.
-          </p>
-          <p class="card-text">
-            Go to <a href="/view/connectors">connectors</a> and see the
-            available connectors.
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col">
-      <div class="card h-100">
-        <h5 class="card-header">
-          <svg class="bi" width="32" height="32">
-            <use xlink:href="/img/bootstrap-icons.svg#rewind"/>
-          </svg>
-          Rewind
-        </h5>
-        <div class="card-body">
-          <p class="card-text">
-            Select a completed task
-            <span class="bpmn-icon-service-task fs-3"></span>
-            and click on
-            <button type="button" class="btn btn-sm btn-primary">
-              <svg class="bi" width="18" height="18" fill="white">
-                <use xlink:href="/img/bootstrap-icons.svg#rewind"/>
-              </svg>
-            </button>
-            to rewind the process to this task. From here, you can try out
-            different paths or inputs.
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="col">
-      <div class="card h-100">
-        <h5 class="card-header">
-          <svg class="bi" width="32" height="32" fill="black">
-            <use xlink:href="/img/bootstrap-icons.svg#info-circle"/>
-          </svg>
-          Status info
-        </h5>
-        <div class="card-body">
-          <p class="card-text">
-          <table class="table">
-            <tbody>
-            <tr>
-              <td>Zeebe-Play version</td>
-              <td id="version-zeebe-play">?</td>
-            </tr>
-            <tr>
-              <td>Zeebe engine version</td>
-              <td id="version-zeebe-engine">?</td>
-            </tr>
-            <tr>
-              <td>Status</td>
-              <td id="status">?</td>
-            </tr>
-            </tbody>
-          </table>
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<footer th:replace="fragments/footer :: footer"></footer>
-</body>
+    <footer th:replace="fragments/footer :: footer"></footer>
+  </body>
 </html>


### PR DESCRIPTION
## Description

* When the URL contains "play.camunda.io", the "Zeebe Play" section of the header is replaced with just "Play" and the icons are removed
* The same applies to the page title
* In the "Demo process" tile on the home view, it then reads "Try out Play by using a demo process" instead of "Try out Zeebe Play by using a demo process"
* I removed the `p` tag in the card body for the status info in the home view as `p` tags cannot contain tables and this broke the auto-formatter.


## Related issues

closes #163 