### PR TITLE
fix: mitigate adblocker issues

### DIFF
--- a/src/main/resources/public/js/incident-modal.js
+++ b/src/main/resources/public/js/incident-modal.js
@@ -91,7 +91,7 @@ async function confirmResolveIncidentModal() {
   }
 
   if (!hasVariables) {
-    track("zeebePlay:single-operation", {
+    track?.("zeebePlay:single-operation", {
       operationType: "RESOLVE_INCIDENT",
       process_id: getBpmnProcessId(),
     });
@@ -117,7 +117,7 @@ async function confirmResolveIncidentModal() {
         "<code>" + variables + "</code>"
       );
 
-      track("zeebePlay:single-operation", {
+      track?.("zeebePlay:single-operation", {
         operationType: "RESOLVE_INCIDENT",
         process_id: getBpmnProcessId(),
       });

--- a/src/main/resources/public/js/mp_integration.js
+++ b/src/main/resources/public/js/mp_integration.js
@@ -35,9 +35,9 @@ if (trackingSetting.token) {
     orgOwner: trackingSetting.orgOwner,
   });
 
-  window.track = (...args) => mixpanel.track(...args);
+  window.track = (...args) => mixpanel.track?.(...args);
 
-  window.track("zeebePlay:view:page", {
+  window.track?.("zeebePlay:view:page", {
     view: getViewName(),
     url: location.href,
   });
@@ -81,7 +81,7 @@ function trackElementInstanceCompletion(elementInstance) {
     bpmnElementType === "PROCESS" &&
     !elementInstanceTrackingState[bpmnElementType + ":" + elementInstance.key]
   ) {
-    track("zeebePlay:bpmnelement:completed", {
+    track?.("zeebePlay:bpmnelement:completed", {
       element_type: "PROCESS",
       process_id: bpmnId,
     });
@@ -93,7 +93,7 @@ function trackElementInstanceCompletion(elementInstance) {
 
   // track element completion
   if (!elementInstanceTrackingState[connectorOrElementType]) {
-    track("zeebePlay:bpmnelement:completed", {
+    track?.("zeebePlay:bpmnelement:completed", {
       [hasConnector ? "connector_type" : "element_type"]:
         connectorOrElementType,
       process_id: bpmnId,
@@ -121,7 +121,7 @@ function trackIncident(incident) {
 
   if (incidentTrackingState[incident.key]) return;
 
-  track("zeebePlay:incident:trigger", {
+  track?.("zeebePlay:incident:trigger", {
     error: incident.errorMessage,
     process_id: getBpmnProcessId(),
   });

--- a/src/main/resources/public/js/view-home.js
+++ b/src/main/resources/public/js/view-home.js
@@ -32,7 +32,7 @@ function enableButtonToCreateInstanceOfDemoProcess(processKey) {
   const createInstanceButton = $("#demo-create-instance-button");
   createInstanceButton.attr("disabled", false);
   createInstanceButton.click(function () {
-    track("zeebePlay:bpmnelement:completed", {
+    track?.("zeebePlay:bpmnelement:completed", {
       element_type: "START_EVENT",
       From: "home",
       process_id: "solos-transport-process",

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -202,7 +202,7 @@ async function rewind(task) {
       newId = await createNewInstanceFromTimerStartEvent(startEvent);
     }
 
-    track("zeebePlay:bpmnelement:completed", {
+    track?.("zeebePlay:bpmnelement:completed", {
       element_type: "START_EVENT",
       From: "rewind",
       process_id: getBpmnProcessId(),

--- a/src/main/resources/public/js/view-process.js
+++ b/src/main/resources/public/js/view-process.js
@@ -142,7 +142,7 @@ function loadInstancesOfProcessLast() {
 }
 
 function createNewProcessInstance() {
-  track("zeebePlay:bpmnelement:completed", {
+  track?.("zeebePlay:bpmnelement:completed", {
     element_type: "START_EVENT",
     From: "processPage",
     process_id: getProcessId(),
@@ -153,7 +153,7 @@ function createNewProcessInstance() {
 }
 
 function createNewProcessInstanceWithVariables() {
-  track("zeebePlay:bpmnelement:completed", {
+  track?.("zeebePlay:bpmnelement:completed", {
     element_type: "START_EVENT",
     From: "processPage",
     process_id: getProcessId(),
@@ -245,7 +245,7 @@ function loadMessageSubscriptionsOfProcess() {
           "</tr>"
       );
 
-      const clickAction = `track('zeebePlay:bpmnelement:completed', {
+      const clickAction = `track?.('zeebePlay:bpmnelement:completed', {
           element_type: 'START_EVENT',
           From: 'processPage',
           process_id: getProcessId()
@@ -322,7 +322,7 @@ function loadTimersOfProcess() {
       );
 
       const action =
-        `track('zeebePlay:bpmnelement:completed', {
+        `track?.('zeebePlay:bpmnelement:completed', {
           element_type: 'START_EVENT',
           From: 'processPage',
           process_id: getProcessId()

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -45,5 +45,5 @@
 
   <script src="/js/incident-modal.js" type="text/javascript"></script>
 
-  <script src="/js/tracking.js" type="text/javascript"></script>
+  <script src="/js/mp_integration.js" type="text/javascript"></script>
 </div>


### PR DESCRIPTION
## Description

* Renamed tracking.js to mp_integration.js (short for mixpanel integration). Adblockers tend to block files called "tracking" or "mixpanel" purely based on filename
* used optional chaining to not fail if the global tracking function is not defined, e.g. if an adblocker still blocks the mp_integration file based on content.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #165 