### PR TITLE
deps: dump hazelcast-exporter to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <maven.version>3.0</maven.version>
     <zeeqs.version>2.8.2</zeeqs.version>
     <eze.version>1.2.0</eze.version>
-    <hazelcast.version>1.4.0-alpha1</hazelcast.version>
+    <hazelcast.version>1.4.0</hazelcast.version>
     <spring-zeebe.version>8.1.17</spring-zeebe.version>
     <camunda-connector-bundle.version>0.17.0</camunda-connector-bundle.version>
     <camunda-connector-sdk.version>0.7.0</camunda-connector-sdk.version>


### PR DESCRIPTION
## Description

Dump `zeebe-hazelcast-exporter` from `1.4.0-alpha1` to [1.4.0](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter/releases/tag/1.4.0).

## Related issues
