### PR TITLE
deps: Dump Zeeqs from 2.8.2 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <maven.version>3.0</maven.version>
-    <zeeqs.version>2.8.2</zeeqs.version>
+    <zeeqs.version>2.9.0</zeeqs.version>
     <eze.version>1.2.0</eze.version>
     <hazelcast.version>1.4.0</hazelcast.version>
     <spring-zeebe.version>8.1.17</spring-zeebe.version>


### PR DESCRIPTION
## Description

Dump `Zeeqs` from `2.8.2` to [2.9.0](https://github.com/camunda-community-hub/zeeqs/releases/tag/2.9.0).

## Related issues
