### PR TITLE
feat: Update to Spring-Zeebe 8.2 and to connectors-bundle 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
     <zeeqs.version>2.9.0</zeeqs.version>
     <eze.version>1.2.0</eze.version>
     <hazelcast.version>1.4.0</hazelcast.version>
-    <spring-zeebe.version>8.1.17</spring-zeebe.version>
-    <camunda-connector-bundle.version>0.17.0</camunda-connector-bundle.version>
+    <spring-zeebe.version>8.2.0</spring-zeebe.version>
+    <camunda-connector-bundle.version>0.18.0</camunda-connector-bundle.version>
     <camunda-connector-sdk.version>0.8.1</camunda-connector-sdk.version>
 
     <kotlin.version>1.8.20</kotlin.version>

--- a/src/main/kotlin/org/camunda/community/zeebe/play/ZeebePlayApplication.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/ZeebePlayApplication.kt
@@ -39,9 +39,6 @@ open class ZeebePlayApplication(
 }
 
 fun main(args: Array<String>) {
-    runApplication<ZeebePlayApplication>(*args) {
-        // Disable the Zeebe-Spring client to avoid configuration issues with the embedded engine.
-        setDefaultProperties(mapOf("zeebe.client.enabled" to "false"))
-    }
+    runApplication<ZeebePlayApplication>(*args)
 }
 

--- a/src/main/kotlin/org/camunda/community/zeebe/play/ZeebePlayApplication.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/ZeebePlayApplication.kt
@@ -39,6 +39,9 @@ open class ZeebePlayApplication(
 }
 
 fun main(args: Array<String>) {
-    runApplication<ZeebePlayApplication>(*args)
+    runApplication<ZeebePlayApplication>(*args) {
+        // Disable the Zeebe-Spring client to avoid configuration issues with the embedded engine.
+        setDefaultProperties(mapOf("zeebe.client.enabled" to "false"))
+    }
 }
 

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
@@ -4,7 +4,6 @@ import io.camunda.connector.api.secret.SecretProvider
 import io.camunda.connector.runtime.util.ConnectorHelper
 import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler
 import io.camunda.zeebe.client.ZeebeClient
-import io.camunda.zeebe.spring.client.lifecycle.ZeebeClientLifecycle
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -28,13 +27,6 @@ class ConnectorsConfig(
 
     @PostConstruct
     fun startConnectors() {
-        if (zeebeClient is ZeebeClientLifecycle) {
-            // The connectors are managed by the Spring Zeebe client itself.
-            // Currently, it is not possible to disable the connectors. See
-            // https://github.com/camunda-community-hub/spring-zeebe/issues/325.
-            return
-        }
-
         if (connectorProperties.mode == ConnectorProperties.ConnectorsMode.ACTIVE) {
             // start all connectors
             connectorService

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,9 @@ zeebe:
     broker.gatewayAddress: 127.0.0.1:26500
     security.plaintext: true
 
+    # Disable the Zeebe-Spring client to avoid configuration issues with the embedded engine.
+    enabled: false
+
     worker:
       hazelcast:
         connection: localhost:5701

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,6 @@ zeebe:
   engine: embedded
 
   client:
-
     broker.gatewayAddress: 127.0.0.1:26500
     security.plaintext: true
 

--- a/src/test/kotlin/org/camunda/community/zeebe/play/ApplicationTests.kt
+++ b/src/test/kotlin/org/camunda/community/zeebe/play/ApplicationTests.kt
@@ -17,7 +17,7 @@ class ApplicationTests(
 
     @Test
     fun `should start application`() {
-        assertThat(mainView).isNotNull();
+        assertThat(mainView).isNotNull()
     }
 
 }


### PR DESCRIPTION
## Description

* dump `spring-zeebe` from `8.1.17` to `8.2.0`
* dump `connectors-bundle` from `0.17.0` to `1.18`
* disable the Spring-Zeebe initialization (configuration issues with the embedded engine)

## Related issues

closes #181