### PR TITLE
fix: Connector secrets with dashes

### DIFF
--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorService.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorService.kt
@@ -19,7 +19,7 @@ class ConnectorService(
     // Connector secrets can be references in a string or in placeholder syntax
     // 1) { x: "secrets.MY_API_KEY"}
     // 2) "https://" + baseUrl + "/{{secrets.MY_API_KEY}}"
-    private val secretRegex = Regex(pattern = "[\"|{]?secrets\\.(\\w+)[\"|}]?")
+    private val secretRegex = Regex(pattern = "[\"|{]?secrets\\.((\\w|-)+)[\"|}]?")
 
     fun getMissingConnectorSecrets(processDefinitionKey: Long): List<String> {
         val referencedSecrets =

--- a/src/test/kotlin/org/camunda/community/zeebe/play/ConnectorServiceTest.kt
+++ b/src/test/kotlin/org/camunda/community/zeebe/play/ConnectorServiceTest.kt
@@ -49,6 +49,12 @@ class ConnectorServiceTest(
                     )
             }
         )
+        .serviceTask(
+            "D", {
+                it.zeebeJobType("D")
+                    .zeebeInput("secrets.D-1", "d")
+            }
+        )
         .done()
 
     @BeforeEach
@@ -82,7 +88,7 @@ class ConnectorServiceTest(
             connectorService.getReferencedConnectorSecrets(processDefinitionKey)
 
         // then
-        assertThat(secrets).hasSize(3).contains("X", "Y", "Z")
+        assertThat(secrets).hasSize(4).contains("X", "Y", "Z", "D-1")
     }
 
     @Test
@@ -94,7 +100,7 @@ class ConnectorServiceTest(
             connectorService.getMissingConnectorSecrets(processDefinitionKey)
 
         // then
-        assertThat(secrets).hasSize(3).contains("X", "Y", "Z")
+        assertThat(secrets).hasSize(4).contains("X", "Y", "Z", "D-1")
     }
 
     @Test
@@ -104,6 +110,7 @@ class ConnectorServiceTest(
             listOf(
                 ConnectorSecret(name = "X", value = "xxx"),
                 ConnectorSecret(name = "Z", value = "zzz"),
+                ConnectorSecret(name = "D-1", value = "ddd"),
             )
         )
 
@@ -123,6 +130,7 @@ class ConnectorServiceTest(
                 ConnectorSecret(name = "X", value = "xxx"),
                 ConnectorSecret(name = "Y", value = "xxx"),
                 ConnectorSecret(name = "Z", value = "zzz"),
+                ConnectorSecret(name = "D-1", value = "ddd"),
             )
         )
 


### PR DESCRIPTION
## Description

Connector secrets can have dashes in their names. 

Adjust the regex to support secrets with dashed.

## Related issues

closes #119