### PR TITLE
fix: invoke SendGrid connector

### DIFF
--- a/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorsResource.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorsResource.kt
@@ -219,7 +219,7 @@ class ConnectorsResource(
         }
 
         override fun <T : Any?> getVariablesAsType(variableType: Class<T>?): T {
-            TODO("Not yet implemented")
+            return objectMapper.readValue(variables, variableType)
         }
 
         override fun toJson(): String {


### PR DESCRIPTION
## Description

Fix the invocation of the SendGrid connector.

The connector failed to invoke because some parts of the integration were not implemented. Add the missing parts. :wrench: 

## Related issues

closes #192 