### PR TITLE
fix: break long variable values in code blocks

### DIFF
--- a/src/main/resources/public/css/app.css
+++ b/src/main/resources/public/css/app.css
@@ -120,6 +120,10 @@
   margin-top: 1em;
 }
 
+code {
+  word-break: break-word;
+}
+
 .decision-canvas-container {
   padding-left: 50px;
   height: 100%;


### PR DESCRIPTION
## Description

Long variables broke the layout, not only in the incident modal, but also in the variables tab. I decided to add the rule to the general `code` tag in alignment with the rules established by Bootstrap here: 

https://github.com/camunda-community-hub/zeebe-play/blob/bdcf7c08ce4a14f3b132ca6c610f72740fc0ce9a/src/main/resources/public/css/bootstrap-reboot.css#L268-L272

## Related issues

contributes to #193 