### PR TITLE
fix: encode quotation marks for element info tooltips

### DIFF
--- a/src/main/resources/public/js/view-bpmn.js
+++ b/src/main/resources/public/js/view-bpmn.js
@@ -562,7 +562,7 @@ function showElementInfo(elementId, bpmnElementType, info) {
     '" data-bs-toggle="tooltip" data-bs-placement="' +
     tooltipPlacement +
     '" data-bs-html="true" data-bs-customClass="bpmn-element-info" class="info-icon" title="' +
-    info +
+    info.replaceAll('"', "&quot;") +
     '">i</div>';
 
   overlays.add(elementId, "element-info", {


### PR DESCRIPTION
## Description

Quotation marks in element info tooltips broke the HTML so the info was not rendered correctly. This PR encodes those quotation marks.

## Related issues

closes #184 