### PR TITLE
fix: remove misplaced condition expression info icons

### DIFF
--- a/src/main/resources/public/css/app.css
+++ b/src/main/resources/public/css/app.css
@@ -12,7 +12,7 @@
 }
 
 .info-icon {
-  background: #007dffb2;
+  background-color: #00000030;
   border-radius: 2px;
   width: 18px;
   height: 18px;
@@ -23,6 +23,12 @@
   font-size: 12px;
   padding-right: 1px;
   margin-top: 5px;
+
+  transition: background-color 0.2s;
+}
+
+.info-icon:hover {
+  background-color: #007dffb2;
 }
 
 .overlay-button {

--- a/src/main/resources/public/js/view-common.js
+++ b/src/main/resources/public/js/view-common.js
@@ -401,9 +401,6 @@ function showInfoOfBpmnElement(element) {
   if (metadata.jobType) {
     info = "job type: " + metadata.jobType;
   }
-  if (metadata.conditionExpression) {
-    info = "condition: " + metadata.conditionExpression;
-  }
   if (metadata.timerDefinition) {
     info = "timer: " + metadata.timerDefinition;
   }


### PR DESCRIPTION
## Description

- Removes the info icons for sequence flows because they can be misplaced
- De-emphasizes all other info icons to no longer compete for attention with the primary CTAs like the start instance button

Closes #213