### PR TITLE
feat: Update connectors-bundle to 0.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,7 @@
     <zeeqs.version>2.9.0</zeeqs.version>
     <eze.version>1.2.0</eze.version>
     <hazelcast.version>1.4.0</hazelcast.version>
-    <spring-zeebe.version>8.2.2</spring-zeebe.version>
     <camunda-connector-bundle.version>0.20.0</camunda-connector-bundle.version>
-    <camunda-connector-sdk.version>0.9.0</camunda-connector-sdk.version>
 
     <kotlin.version>1.8.22</kotlin.version>
     <spring.boot.version>2.7.12</spring.boot.version>
@@ -75,9 +73,15 @@
       </dependency>
 
       <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>spring-zeebe-starter</artifactId>
-        <version>${spring-zeebe.version}</version>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>spring-boot-starter-camunda-connectors</artifactId>
+        <version>${camunda-connector-bundle.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>connector-runtime-bundle</artifactId>
+        <version>${camunda-connector-bundle.version}</version>
       </dependency>
 
       <dependency>
@@ -90,24 +94,6 @@
         <groupId>io.zeebe.hazelcast</groupId>
         <artifactId>zeebe-hazelcast-exporter</artifactId>
         <version>${hazelcast.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda.connector</groupId>
-        <artifactId>connector-runtime-bundle</artifactId>
-        <version>${camunda-connector-bundle.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda.connector</groupId>
-        <artifactId>connector-runtime-util</artifactId>
-        <version>${camunda-connector-sdk.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda.connector</groupId>
-        <artifactId>connector-validation</artifactId>
-        <version>${camunda-connector-sdk.version}</version>
       </dependency>
 
       <dependency>
@@ -221,9 +207,14 @@
     <!-- Zeebe dependencies -->
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>spring-zeebe-starter</artifactId>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>spring-boot-starter-camunda-connectors</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-runtime-bundle</artifactId>
+     </dependency>
 
     <dependency>
       <groupId>org.camunda.community</groupId>
@@ -239,28 +230,6 @@
     <dependency>
       <groupId>io.zeebe.hazelcast</groupId>
       <artifactId>zeebe-hazelcast-exporter</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda.connector</groupId>
-      <artifactId>connector-runtime-bundle</artifactId>
-      <exclusions>
-        <!-- The runtime causes errors in Spring. We don't need it. -->
-        <exclusion>
-          <groupId>io.camunda</groupId>
-          <artifactId>spring-zeebe-connector-runtime</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda.connector</groupId>
-      <artifactId>connector-runtime-util</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda.connector</groupId>
-      <artifactId>connector-validation</artifactId>
     </dependency>
 
     <!-- Database drivers -->

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <eze.version>1.2.0</eze.version>
     <hazelcast.version>1.4.0</hazelcast.version>
     <spring-zeebe.version>8.2.2</spring-zeebe.version>
-    <camunda-connector-bundle.version>0.18.2</camunda-connector-bundle.version>
+    <camunda-connector-bundle.version>0.20.0</camunda-connector-bundle.version>
     <camunda-connector-sdk.version>0.9.0</camunda-connector-sdk.version>
 
     <kotlin.version>1.8.22</kotlin.version>

--- a/src/main/kotlin/org/camunda/community/zeebe/play/ZeebePlayApplication.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/ZeebePlayApplication.kt
@@ -1,6 +1,7 @@
 package org.camunda.community.zeebe.play
 
 
+import io.camunda.connector.runtime.OutboundConnectorsAutoConfiguration
 import io.zeebe.zeeqs.importer.hazelcast.HazelcastImporter
 import io.zeebe.zeeqs.importer.hazelcast.HazelcastProperties
 import org.camunda.community.zeebe.play.zeebe.ZeebeService
@@ -12,7 +13,7 @@ import javax.annotation.PostConstruct
 import javax.annotation.PreDestroy
 
 
-@SpringBootApplication
+@SpringBootApplication(exclude = [OutboundConnectorsAutoConfiguration::class])
 @EnableSpringDataWebSupport
 open class ZeebePlayApplication(
     val hazelcastProperties: HazelcastProperties,

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorService.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorService.kt
@@ -1,7 +1,7 @@
 package org.camunda.community.zeebe.play.connectors
 
 import io.camunda.connector.impl.outbound.OutboundConnectorConfiguration
-import io.camunda.connector.runtime.util.discovery.SPIConnectorDiscovery
+import io.camunda.connector.runtime.core.discovery.SPIConnectorDiscovery
 import io.camunda.zeebe.model.bpmn.Bpmn
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput

--- a/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/connectors/ConnectorsConfig.kt
@@ -1,8 +1,8 @@
 package org.camunda.community.zeebe.play.connectors
 
 import io.camunda.connector.api.secret.SecretProvider
-import io.camunda.connector.runtime.util.ConnectorHelper
-import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler
+import io.camunda.connector.runtime.core.ConnectorHelper
+import io.camunda.connector.runtime.core.outbound.ConnectorJobHandler
 import io.camunda.zeebe.client.ZeebeClient
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.domain.EntityScan

--- a/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorsResource.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/rest/ConnectorsResource.kt
@@ -3,8 +3,8 @@ package org.camunda.community.zeebe.play.rest
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.camunda.connector.impl.outbound.OutboundConnectorConfiguration
-import io.camunda.connector.runtime.util.ConnectorHelper
-import io.camunda.connector.runtime.util.outbound.ConnectorJobHandler
+import io.camunda.connector.runtime.core.ConnectorHelper
+import io.camunda.connector.runtime.core.outbound.ConnectorJobHandler
 import io.camunda.zeebe.client.ZeebeClient
 import io.camunda.zeebe.client.api.response.ActivatedJob
 import io.camunda.zeebe.model.bpmn.Bpmn

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,14 @@ zeebe:
     #  - name: SLACK_OAUTH_TOKEN
     #    value: my-slack-oauth-token
 
+camunda:
+  # disable inbound connector
+  connector:
+    polling:
+      enabled: false
+    webhook:
+      enabled: false
+
 spring:
   datasource:
     url: jdbc:h2:mem:zeeqs;DB_CLOSE_DELAY=-1


### PR DESCRIPTION
## Description

Replace the dependency to `spring-zeebe-starter` and to the Camunda connector artifacts with the new recommended `spring-boot-starter-camunda-connectors` in version `0.20.0`.

Disable the inbound and outbound connectors in the configuration. 

## Related issues
