### PR TITLE
feat: Add health probes and metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,11 @@
       <artifactId>spring-boot-starter-thymeleaf</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
     <!-- JSON serialization -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/kotlin/org/camunda/community/zeebe/play/ZeebePlayApplication.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/ZeebePlayApplication.kt
@@ -2,10 +2,8 @@ package org.camunda.community.zeebe.play
 
 
 import io.camunda.connector.runtime.OutboundConnectorsAutoConfiguration
-import io.zeebe.zeeqs.importer.hazelcast.HazelcastImporter
-import io.zeebe.zeeqs.importer.hazelcast.HazelcastProperties
+import org.camunda.community.zeebe.play.services.HazelcastService
 import org.camunda.community.zeebe.play.zeebe.ZeebeService
-import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.web.config.EnableSpringDataWebSupport
@@ -16,24 +14,19 @@ import javax.annotation.PreDestroy
 @SpringBootApplication(exclude = [OutboundConnectorsAutoConfiguration::class])
 @EnableSpringDataWebSupport
 open class ZeebePlayApplication(
-    val hazelcastProperties: HazelcastProperties,
-    val hazelcastImporter: HazelcastImporter,
-    val zeebeService: ZeebeService
+    private val hazelcastService: HazelcastService,
+    private val zeebeService: ZeebeService
 ) {
-
-    private val logger = LoggerFactory.getLogger(ZeebePlayApplication::class.java)
 
     @PostConstruct
     fun init() {
         zeebeService.start()
-
-        logger.info("Connecting to Hazelcast: '$hazelcastProperties'")
-        hazelcastImporter.start(hazelcastProperties)
-        logger.info("Connected to Hazelcast!")
+        hazelcastService.start()
     }
 
     @PreDestroy
     fun stop() {
+        hazelcastService.stop()
         zeebeService.stop()
     }
 

--- a/src/main/kotlin/org/camunda/community/zeebe/play/actuators/HazelcastReadinessIndicator.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/actuators/HazelcastReadinessIndicator.kt
@@ -1,0 +1,23 @@
+package org.camunda.community.zeebe.play.actuators
+
+import org.camunda.community.zeebe.play.services.HazelcastService
+import org.springframework.boot.actuate.availability.ReadinessStateHealthIndicator
+import org.springframework.boot.availability.ApplicationAvailability
+import org.springframework.boot.availability.AvailabilityState
+import org.springframework.boot.availability.ReadinessState
+import org.springframework.stereotype.Component
+
+@Component
+class HazelcastReadinessIndicator(
+    availability: ApplicationAvailability,
+    private val hazelcastService: HazelcastService
+) : ReadinessStateHealthIndicator(availability) {
+
+    override fun getState(applicationAvailability: ApplicationAvailability): AvailabilityState {
+        return when (hazelcastService.isRunning()) {
+            true -> ReadinessState.ACCEPTING_TRAFFIC
+            else -> ReadinessState.REFUSING_TRAFFIC
+        }
+    }
+
+}

--- a/src/main/kotlin/org/camunda/community/zeebe/play/actuators/ZeebeEngineReadinessIndicator.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/actuators/ZeebeEngineReadinessIndicator.kt
@@ -1,0 +1,23 @@
+package org.camunda.community.zeebe.play.actuators
+
+import org.camunda.community.zeebe.play.zeebe.ZeebeService
+import org.springframework.boot.actuate.availability.ReadinessStateHealthIndicator
+import org.springframework.boot.availability.ApplicationAvailability
+import org.springframework.boot.availability.AvailabilityState
+import org.springframework.boot.availability.ReadinessState
+import org.springframework.stereotype.Component
+
+@Component
+class ZeebeEngineReadinessIndicator(
+    availability: ApplicationAvailability,
+    private val zeebeService: ZeebeService
+) : ReadinessStateHealthIndicator(availability) {
+
+    override fun getState(applicationAvailability: ApplicationAvailability): AvailabilityState {
+        return when (zeebeService.isRunning()) {
+            true -> ReadinessState.ACCEPTING_TRAFFIC
+            else -> ReadinessState.REFUSING_TRAFFIC
+        }
+    }
+
+}

--- a/src/main/kotlin/org/camunda/community/zeebe/play/services/HazelcastService.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/services/HazelcastService.kt
@@ -1,0 +1,37 @@
+package org.camunda.community.zeebe.play.services
+
+import io.zeebe.zeeqs.importer.hazelcast.HazelcastImporter
+import io.zeebe.zeeqs.importer.hazelcast.HazelcastProperties
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class HazelcastService(
+    val hazelcastProperties: HazelcastProperties,
+    val hazelcastImporter: HazelcastImporter,
+) {
+
+    private val logger = LoggerFactory.getLogger(HazelcastService::class.java)
+
+    private var isRunning = false
+
+    fun start() {
+        logger.info("Connecting to Hazelcast: '$hazelcastProperties'")
+        hazelcastImporter.start(hazelcastProperties)
+        logger.info("Connected to Hazelcast!")
+
+        isRunning = true
+    }
+
+    fun stop() {
+        logger.info("Stopping Hazelcast")
+        hazelcastImporter.stop()
+
+        isRunning = false
+    }
+
+    fun isRunning(): Boolean {
+        return isRunning
+    }
+
+}

--- a/src/main/kotlin/org/camunda/community/zeebe/play/zeebe/EmbeddedZeebeConfig.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/zeebe/EmbeddedZeebeConfig.kt
@@ -32,18 +32,24 @@ open class EmbeddedZeebeConfig {
         return engine.createClient()
     }
 
-    class EmbeddedZeebeService(val engine: ZeebeEngine): ZeebeService {
+    class EmbeddedZeebeService(val engine: ZeebeEngine) : ZeebeService {
 
         private val logger = LoggerFactory.getLogger(EmbeddedZeebeService::class.java)
+
+        private var isRunning = false
 
         override fun start() {
             logger.info("Start embedded Zeebe engine at '{}'", engine.getGatewayAddress())
             engine.start()
+
+            isRunning = true
         }
 
         override fun stop() {
             logger.info("Stop embedded Zeebe engine")
             engine.stop()
+
+            isRunning = false
         }
 
         override fun getCurrentTime(): Instant {
@@ -53,6 +59,10 @@ open class EmbeddedZeebeConfig {
         override fun increaseTime(duration: Duration): Long {
             engine.clock().increaseTime(timeToAdd = duration)
             return getCurrentTime().toEpochMilli()
+        }
+
+        override fun isRunning(): Boolean {
+            return isRunning
         }
     }
 

--- a/src/main/kotlin/org/camunda/community/zeebe/play/zeebe/ZeebeService.kt
+++ b/src/main/kotlin/org/camunda/community/zeebe/play/zeebe/ZeebeService.kt
@@ -13,4 +13,6 @@ interface ZeebeService {
 
     fun increaseTime(duration: Duration): Long
 
+    fun isRunning(): Boolean
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ zeebe:
 
     worker:
       hazelcast:
-        connection: localhost:5701
+        connection: 127.0.0.1:5701
         connectionTimeout: PT1M
         ringbuffer: zeebe
         connectionInitialBackoff: PT15S
@@ -24,6 +24,9 @@ zeebe:
 
   clock:
     endpoint: 127.0.0.1:9600/actuator/clock
+
+  health:
+    endpoint: 127.0.0.1:9600/actuator/health
 
   connectors:
     # connector mode options: 'active' (as job workers) / 'passive' (trigger manually in process)
@@ -59,3 +62,28 @@ spring:
     # enable GraphiQL inspection tool by default
     graphiql:
       enabled: true
+
+management:
+
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics
+
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
+
+  endpoint:
+    health:
+      show-details: always
+      show-components: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState, zeebeEngineReadinessIndicator, hazelcastReadinessIndicator
+
+


### PR DESCRIPTION
## Description

* Add Spring Boot Actuator 
* Enable health and metrics endpoint
* Include a Zeebe engine and a Hazelcast status check to the readiness probe

Liveness:
```
// request:
http://localhost:8080/actuator/health/liveness

// response:
{"status":"UP"}
```

Readiness:
```
// request:
http://localhost:8080/actuator/health/readiness

// response:
{"status":"UP","components":{"hazelcastReadinessIndicator":{"status":"UP"},"readinessState":{"status":"UP"},"zeebeEngineReadinessIndicator":{"status":"UP"}}}
```

## Related issues

