### PR TITLE
fix: handle variable and secret values as text

### DIFF
--- a/src/main/resources/public/js/incident-modal.js
+++ b/src/main/resources/public/js/incident-modal.js
@@ -113,8 +113,7 @@ async function confirmResolveIncidentModal() {
 
       showNotificationSuccess(
         "set-variables-" + key,
-        "Variables set successfully",
-        "<code>" + variables + "</code>"
+        "Variables set successfully"
       );
 
       track?.("zeebePlay:single-operation", {
@@ -127,7 +126,7 @@ async function confirmResolveIncidentModal() {
     .fail(
       showFailure(
         "set-variables" + scope,
-        "Failed to set variables <code>" + variables + "</code>."
+        "Failed to set variables."
       )
     );
 }

--- a/src/main/resources/public/js/view-connectors.js
+++ b/src/main/resources/public/js/view-connectors.js
@@ -22,9 +22,9 @@ function loadConnectorSecrets() {
       let row = `
         <tr>
           <td>${index + 1}</td>
-          <td>${secret.name}</td>
+          <td class="secretName"></td>
           <td>
-            <code>${secret.value}</code>
+            <code></code>
           </td>
           <td>
             <button id="${editButtonId}" type="button" class="btn btn-sm btn-secondary" title="Edit" data-bs-toggle="modal"
@@ -41,6 +41,9 @@ function loadConnectorSecrets() {
         </tr>`;
 
       $("#connector-secrets-table tbody:last-child").append(row);
+
+      $("#connector-secrets-table tbody:last-child tr:last-child .secretName").text(secret.name);
+      $("#connector-secrets-table tbody:last-child tr:last-child code").text(secret.value);
 
       $("#" + editButtonId).click(function () {
         // fill modal

--- a/src/main/resources/public/js/view-process-instance.js
+++ b/src/main/resources/public/js/view-process-instance.js
@@ -578,8 +578,6 @@ function loadVariablesOfProcessInstance() {
 
       let scopeElement = formatBpmnElementInstance(scope.element);
 
-      let valueFormatted = "<code>" + variable.value + "</code>";
-
       let lastUpdatedFormatted =
         '<div class="row row-cols-1">' +
         '<div class="col">' +
@@ -665,9 +663,7 @@ function loadVariablesOfProcessInstance() {
           "<td>" +
           variable.name +
           "</td>" +
-          "<td>" +
-          valueFormatted +
-          "</td>" +
+          "<td><code></code></td>" +
           "<td>" +
           scopeFormatted +
           "</td>" +
@@ -685,6 +681,8 @@ function loadVariablesOfProcessInstance() {
           "</td>" +
           "</tr>"
       );
+
+      $("#variables-of-process-instance-table > tbody:last-child > tr:last-child code").text(variable.value);
     });
   });
 }
@@ -719,8 +717,7 @@ function setVariablesModal() {
       const toastId = "set-variables-" + key;
       showNotificationSuccess(
         toastId,
-        "Variables set successfully",
-        "<code>" + variables + "</code>."
+        "Variables set successfully"
       );
 
       loadVariablesOfProcessInstance();
@@ -728,7 +725,7 @@ function setVariablesModal() {
     .fail(
       showFailure(
         "set-variables" + scope,
-        "Failed to set variables <code>" + variables + "</code>."
+        "Failed to set variables."
       )
     );
 }


### PR DESCRIPTION
## Description

This change prevents HTML injection for variable names and connector secrets. For the tables this was achieved by targeting the empty container element via jQuery and adding the content as text instead of adding it as HTML.

I removed the variable payload from the notifications as I don't think it's needed there.

## Related issues

closes #248 